### PR TITLE
Allow use of BSON::ObjectId('string')

### DIFF
--- a/lib/moped/bson/object_id.rb
+++ b/lib/moped/bson/object_id.rb
@@ -3,6 +3,10 @@ require "socket"
 
 module Moped
   module BSON
+    def self.ObjectId(string)
+      ObjectId.from_string(string)
+    end
+
     class ObjectId
 
       # Formatting string for outputting an ObjectId.
@@ -44,6 +48,10 @@ module Moped
 
       def to_s
         @@string_format % data
+      end
+
+      def inspect
+        %Q{Moped::BSON::ObjectId('#{to_s}')}
       end
 
       # Return the UTC time at which this ObjectId was generated. This may

--- a/spec/moped/bson/object_id_spec.rb
+++ b/spec/moped/bson/object_id_spec.rb
@@ -25,6 +25,26 @@ describe Moped::BSON::ObjectId do
     end
   end
 
+  describe "()" do
+
+    context "when the string is valid" do
+
+      it "initializes with the strings bytes" do
+        Moped::BSON::ObjectId.should_receive(:new).with(bytes)
+        Moped::BSON::ObjectId("4e4d66343b39b68407000001")
+      end
+    end
+
+    context "when the string is not valid" do
+
+      it "raises an error" do
+        expect {
+          Moped::BSON::ObjectId("asadsf")
+        }.to raise_error(Moped::Errors::InvalidObjectId)
+      end
+    end
+  end
+
   describe ".legal?" do
 
     context "when the string is too short to be an object id" do
@@ -127,6 +147,14 @@ describe Moped::BSON::ObjectId do
 
     it "returns a hex string representation of the id" do
       Moped::BSON::ObjectId.new(bytes).to_s.should eq "4e4d66343b39b68407000001"
+    end
+
+  end
+
+  describe '#inspect' do
+
+    it "returns an inspection of the id" do
+      Moped::BSON::ObjectId.new(bytes).inspect.should eq "Moped::BSON::ObjectId('4e4d66343b39b68407000001')"
     end
 
   end


### PR DESCRIPTION
Bring parity to official BSON gem aliasing BSON::ObjectId.from_string to BSON::ObjectId().

Includes tests and inspect which allows for copy/paste of objectids.
