### PR TITLE
count take care about limit and skip

### DIFF
--- a/lib/moped/query.rb
+++ b/lib/moped/query.rb
@@ -146,7 +146,9 @@ module Moped
     def count
       result = collection.database.command(
         count: collection.name,
-        query: selector
+        query: selector,
+        limit: operation.limit,
+        skip: operation.skip
       )
 
       result["n"]

--- a/spec/moped/query_spec.rb
+++ b/spec/moped/query_spec.rb
@@ -177,6 +177,16 @@ describe Moped::Query do
         users.insert(documents)
         users.find(scope: scope).count.should eq 2
       end
+
+      it 'return the number of document with limit' do
+        users.insert(documents)
+        users.find(scope: scope).limit(1).count.should eq 1
+      end
+
+      it 'return the number of document with limit and offset' do
+        users.insert(documents)
+        users.find(scope: scope).limit(1).skip(4).count.should eq 0
+      end
     end
 
     describe "#update" do


### PR DESCRIPTION
the `Query#count` don't care about limit and skip. But the mongo-ruby-driver take care about this filter.

I think it's better to have this behavior instead actually, more logic.
