### PR TITLE
Query#and_modify addition

### DIFF
--- a/lib/moped/query.rb
+++ b/lib/moped/query.rb
@@ -292,11 +292,11 @@ module Moped
     # Update an existing document with +change+ and return it
     #
     # @example
-    #  db[:people].find(name: "John").and_modify(name: "Jon") # => [{ _id: objectId, name: "Jon" }]
-    #  db[:people].find(name: "John").and_modify(name: "Jon", :new => false) # => [{ _id: objectId, name: "John" }]
-    #  db[:people].find(name: "John").and_modify(name: "Jon", :upsert => true) # => [{ _id: objectId, name: "Jon" }]
-    #  db[:people].find.sort(_id: -1).and_modify(name: "Jon") # => [{ _id: objectId, name: "Jon" }]
-    #  db[:people].find(name: "John").select(name: 0).and_modify(name: "Jon") # => [{ _id: objectId }]
+    #  db[:people].find(name: "John").modify(name: "Jon") # => [{ _id: objectId, name: "Jon" }]
+    #  db[:people].find(name: "John").modify(name: "Jon", :new => false) # => [{ _id: objectId, name: "John" }]
+    #  db[:people].find(name: "John").modify(name: "Jon", :upsert => true) # => [{ _id: objectId, name: "Jon" }]
+    #  db[:people].find.sort(_id: -1).modify(name: "Jon") # => [{ _id: objectId, name: "Jon" }]
+    #  db[:people].find(name: "John").select(name: 0).modify(name: "Jon") # => [{ _id: objectId }]
     #
     # @param [ Hash ] change The changes to make to the document
     # @param [ Hash ] options The options
@@ -305,7 +305,7 @@ module Moped
     # @option options :upsert set to true if you want to upsert
     #
     # @return [ Hash ] The document
-    def and_modify(change, options = {})
+    def modify(change, options = {})
       options = {
         :"new" => true,
         upsert: false

--- a/spec/moped/query_spec.rb
+++ b/spec/moped/query_spec.rb
@@ -25,12 +25,12 @@ describe Moped::Query do
       }.to raise_exception(Moped::Errors::QueryFailure)
     end
     
-    describe "#and_modify" do
+    describe "#modify" do
       
       context "when a sort exists" do
         before do
           users.insert(documents)
-          @modified_doc = users.find.sort(_id: -1).and_modify(:scope => 'new_scope')
+          @modified_doc = users.find.sort(_id: -1).modify(:scope => 'new_scope')
         end
         
         it "updates the document specified by the sort" do
@@ -42,7 +42,7 @@ describe Moped::Query do
       context "when a selection has been made" do
         before do
           users.insert(documents)
-          @modified_doc = users.find(:_id => documents.first["_id"]).select(scope: 1, _id: 0).and_modify(:scope => 'new_scope')
+          @modified_doc = users.find(:_id => documents.first["_id"]).select(scope: 1, _id: 0).modify(:scope => 'new_scope')
         end
         
         it "the selected fields are returned" do
@@ -55,7 +55,7 @@ describe Moped::Query do
         before do
           users.insert(documents)
           @first_document_id = documents.first["_id"]
-          @modified_doc = users.find(:_id => @first_document_id).and_modify(:scope => 'new_scope')
+          @modified_doc = users.find(:_id => @first_document_id).modify(:scope => 'new_scope')
         end
       
         it "updates the selected document" do
@@ -74,7 +74,7 @@ describe Moped::Query do
         
         it "upserts a document when none is found" do
           missing_key = Moped::BSON::ObjectId.new
-          modified_doc = users.find(:_id => missing_key).and_modify({ :scope => 'new_scope' }, :upsert => true)
+          modified_doc = users.find(:_id => missing_key).modify({ :scope => 'new_scope' }, :upsert => true)
           
           modified_doc["_id"].should eq(missing_key)
           modified_doc["scope"].should eq('new_scope')
@@ -85,7 +85,7 @@ describe Moped::Query do
         
         it "upserts with a modifier" do
           missing_key = Moped::BSON::ObjectId.new
-          modified_doc = users.find(:_id => missing_key).and_modify({"$inc" => {:seq => 1}}, :upsert => true)
+          modified_doc = users.find(:_id => missing_key).modify({"$inc" => {:seq => 1}}, :upsert => true)
           
           modified_doc["_id"].should eq(missing_key)
           modified_doc["seq"].should == 1
@@ -99,7 +99,7 @@ describe Moped::Query do
         before do
           users.insert(documents)
           @first_document_id = documents.first["_id"]
-          @modified_doc = users.find(:_id => @first_document_id).and_modify({:scope => 'new_scope'}, :new => false)
+          @modified_doc = users.find(:_id => @first_document_id).modify({:scope => 'new_scope'}, :new => false)
         end
         
         it "updates the selected document" do


### PR DESCRIPTION
I'd like moped to provide a find_and_modify facility. Specifically I'd like to be able to use:

```
doc = collection.find(:key => my_key).and_modify(:val => my_val)
```

I roughed this out for initial discussion purposes. Very open to feedback/changes here.
