### PR TITLE
Don't raise, when droping non existent collection. Return false instead.

### DIFF
--- a/lib/moped/collection.rb
+++ b/lib/moped/collection.rb
@@ -22,7 +22,11 @@ module Moped
     #
     # @since 1.0.0
     def drop
-      database.command(drop: name)
+      begin
+        database.command(drop: name)
+      rescue Moped::Errors::OperationFailure => e
+        false
+      end
     end
 
     # Build a query for this collection.

--- a/spec/moped/collection_spec.rb
+++ b/spec/moped/collection_spec.rb
@@ -8,14 +8,26 @@ describe Moped::Collection do
   let(:scope) { object_id }
 
   describe "#drop" do
-    before do
-      session.drop
-      session.command create: "users"
+    context "when collection exists" do
+      before do
+        session.drop
+        session.command create: "users"
+      end
+
+      it "drops the collection" do
+        result = session[:users].drop
+        result["ns"].should eq "moped_test.users"
+      end
     end
 
-    it "drops the collection" do
-      result = session[:users].drop
-      result["ns"].should eq "moped_test.users"
+    context "when collection doesn't exist" do
+      before do
+        session.drop
+      end
+
+      it "works" do
+        session[:users].drop.should be_false
+      end
     end
   end
 


### PR DESCRIPTION
Fixes http://github.com/mongoid/mongoid/issues/2096.
