### PR TITLE
Fix endian directives order

### DIFF
--- a/lib/moped/connection.rb
+++ b/lib/moped/connection.rb
@@ -90,7 +90,7 @@ module Moped
         reply.flags,
         reply.cursor_id,
         reply.offset,
-        reply.count = @sock.read(36).unpack('l5<q<l2<')
+        reply.count = @sock.read(36).unpack('l<5q<l<2')
 
       if reply.count == 0
         reply.documents = []


### PR DESCRIPTION
The endianness operator was ignored because the counter was before it.

On little endian systems this seem to be ok, but on big endian systems this will lead to errors.
