### PR TITLE
Database connection set with TCP_NODELAY

### DIFF
--- a/lib/moped/connection.rb
+++ b/lib/moped/connection.rb
@@ -191,6 +191,7 @@ module Moped
           Timeout::timeout(timeout) do
             sock = new(host, port)
             sock.set_encoding('binary')
+            sock.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
             sock
           end
         end


### PR DESCRIPTION
One of our projects runs its specs in 43 seconds without TCP_NODELAY,
8 seconds with it. Most of the overhead is due to sock.read(), sleeping.
