### PR TITLE
Fix order of parameters for __bson_load__ in Timestamp

### DIFF
--- a/lib/moped/bson/timestamp.rb
+++ b/lib/moped/bson/timestamp.rb
@@ -3,7 +3,7 @@ module Moped
     class Timestamp < Struct.new(:seconds, :increment)
       class << self
         def __bson_load__(io)
-          new(*io.read(8).unpack('l2'))
+          new(*io.read(8).unpack('l2').reverse)
         end
       end
 

--- a/spec/moped/bson/document_spec.rb
+++ b/spec/moped/bson/document_spec.rb
@@ -292,8 +292,8 @@ describe Moped::BSON::Document do
 
   context "timestamp" do
     it_behaves_like "a serializable bson document" do
-      let(:raw) { "\x10\x00\x00\x00\x11n\x00d\x00\x00\x00d\x00\x00\x00\x00" }
-      let(:doc) { {"n" => Moped::BSON::Timestamp.new(100, 100)} }
+      let(:raw) { "\x10\x00\x00\x00\x11n\x00e\x00\x00\x00d\x00\x00\x00\x00" }
+      let(:doc) { {"n" => Moped::BSON::Timestamp.new(100, 101)} }
     end
   end
 


### PR DESCRIPTION
Parsing timestamps switched seconds and increment around. The spec example didn't pick this up, as it used the same value for seconds and increment.
