### PR TITLE
Reconnecting TCPSocket in Moped::Connection if it is disconnected in the middle of a call.

### DIFF
--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -471,7 +471,7 @@ module Moped
     end
 
     def connection
-      @connection ||= Connection.new
+      @connection ||= Connection.new(ip_address, port, timeout)
     end
 
     def connected?
@@ -493,7 +493,7 @@ module Moped
     # Raises Moped::ConnectionError if the connection times out.
     # Raises Moped::ConnectionError if the server is unavailable.
     def connect
-      connection.connect ip_address, port, timeout
+      connection.connect
       @down_at = nil
     end
 

--- a/spec/moped/node_spec.rb
+++ b/spec/moped/node_spec.rb
@@ -77,6 +77,21 @@ describe Moped::Node, replica_set: true do
         end.should raise_exception(Moped::Errors::SocketError)
       end
     end
-  end
 
+    context "when the socket gets disconnected in the middle of a send" do
+      before do
+        Moped::Node.__send__(:public, :connection)
+      end
+
+      it "reconnects the socket" do
+        node.connection.stub(:connected?).and_return(true)
+        node.connection.instance_variable_set(:@sock, nil)
+        lambda do
+          node.ensure_connected do
+            node.command("admin", ping: 1)
+          end
+        end.should_not raise_exception
+      end
+    end
+  end
 end

--- a/spec/support/replica_set_simulator.rb
+++ b/spec/support/replica_set_simulator.rb
@@ -199,6 +199,7 @@ module Support
       # Proxies a single message from client to the mongo connection.
       def proxy(client, mongo)
         if @hiccup_on_next_message
+          @hiccup_on_next_message = false
           return hiccup
         end
 


### PR DESCRIPTION
Reconnects the socket in Moped::Connection if it is disconnected and the class wants to do something with it. Empirically fixes the issue on my localhost I described at https://groups.google.com/forum/?fromgroups#!topic/mongoid/TRX4_IoT-ik.
