### PR TITLE
Update .travis.yml: disable indy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,21 +6,21 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-19mode
       jdk: oraclejdk7
-      env: JRUBY_OPTS="-Xmx512m"
+      env: JRUBY_OPTS="-Xmx512m -Xcompile.invokedynamic=false"
     - rvm: jruby-19mode
       jdk: openjdk7
-      env: JRUBY_OPTS="-Xmx512m"
+      env: JRUBY_OPTS="-Xmx512m -Xcompile.invokedynamic=false"
     - rvm: jruby-head
       jdk: oraclejdk7
-      env: JRUBY_OPTS="-Xmx512m"
+      env: JRUBY_OPTS="-Xmx512m -Xcompile.invokedynamic=false"
     - rvm: jruby-head
       jdk: openjdk7
-      env: JRUBY_OPTS="-Xmx512m"
+      env: JRUBY_OPTS="-Xmx512m -Xcompile.invokedynamic=false"
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
       jdk: oraclejdk7
-      env: JRUBY_OPTS="-Xmx512m"
+      env: JRUBY_OPTS="-Xmx512m -Xcompile.invokedynamic=false"
     - rvm: jruby-head
       jdk: openjdk7
-      env: JRUBY_OPTS="-Xmx512m"
+      env: JRUBY_OPTS="-Xmx512m -Xcompile.invokedynamic=false"


### PR DESCRIPTION
Until JRuby 1.7 use of invokedynamic stabilizes and we get newer OpenJDK 7
