### PR TITLE
Quit using "admin" database by default when running getlasterror

### DIFF
--- a/lib/moped/session/context.rb
+++ b/lib/moped/session/context.rb
@@ -57,7 +57,7 @@ module Moped
           if safe?
             node.pipeline do
               node.insert(database, collection, documents, options)
-              node.command("admin", { getlasterror: 1 }.merge(safety))
+              node.command(database, { getlasterror: 1 }.merge(safety))
             end
           else
             node.insert(database, collection, documents, options)
@@ -70,7 +70,7 @@ module Moped
           if safe?
             node.pipeline do
               node.update(database, collection, selector, change, options)
-              node.command("admin", { getlasterror: 1 }.merge(safety))
+              node.command(database, { getlasterror: 1 }.merge(safety))
             end
           else
             node.update(database, collection, selector, change, options)
@@ -83,7 +83,7 @@ module Moped
           if safe?
             node.pipeline do
               node.remove(database, collection, selector, options)
-              node.command("admin", { getlasterror: 1 }.merge(safety))
+              node.command(database, { getlasterror: 1 }.merge(safety))
             end
           else
             node.remove(database, collection, selector, options)


### PR DESCRIPTION
When using the "admin" database by default in environments with authentication, getlasterror fails hard.  Thus, use the current database.
