### PR TITLE
Find collection names even when they contain system.

### DIFF
--- a/lib/moped/database.rb
+++ b/lib/moped/database.rb
@@ -54,7 +54,7 @@ module Moped
     #
     # @since 1.0.0
     def collection_names
-      namespaces = Collection.new(self, "system.namespaces").find(name: { "$not" => /system|\$/ })
+      namespaces = Collection.new(self, "system.namespaces").find(name: { "$not" => /#{name}\.system|\$/ })
       namespaces.map do |doc|
         _name = doc["name"]
         _name[name.length + 1, _name.length]

--- a/spec/moped/collection_spec.rb
+++ b/spec/moped/collection_spec.rb
@@ -73,20 +73,6 @@ describe Moped::Collection do
     end
   end
 
-  describe "#collection_names" do
-    before do
-      session.drop
-      session.command create: "users"
-      session.command create: "comments"
-    end
-
-    it "returns the name of all non system collections" do
-      collection_names = session.collection_names
-      collection_names.should be_instance_of(Array)
-      collection_names.sort.should eq %w[ users comments ].sort
-    end
-  end
-
   describe "#collections" do
     before do
       session.drop

--- a/spec/moped/database_spec.rb
+++ b/spec/moped/database_spec.rb
@@ -62,4 +62,52 @@ describe Moped::Database do
       end
     end
   end
+
+
+  describe "#collection_names" do
+
+    let(:collection_names) do
+      session.collection_names
+    end
+
+    before :each do
+      session.drop
+      names.map do |name|
+        session.command create: name
+      end
+    end
+
+    context "when name doesn't include system" do
+
+      let(:names) do
+        %w[ users comments ]
+      end
+
+      it "returns the name of all non system collections" do
+        collection_names.sort.should eq %w[ users comments ].sort
+      end
+    end
+
+    context "when name includes system not at the beginning" do
+
+      let(:names) do
+        %w[ users comments_system_fu ]
+      end
+
+      it "returns the name of all non system collections" do
+        collection_names.sort.should eq %w[ users comments_system_fu ].sort
+      end
+    end
+
+    context "when name includes system at the beginning" do
+
+      let(:names) do
+        %w[ users system_comments_fu ]
+      end
+
+      it "returns the name of all non system collections" do
+        collection_names.sort.should eq %w[ users ].sort
+      end
+    end
+  end
 end


### PR DESCRIPTION
But not at the beginning. Fixes #63.
