### PR TITLE
Fixed a typo in the query failure handler of Node

### DIFF
--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -343,7 +343,7 @@ module Moped
 
       process(operation) do |reply|
         if reply.query_failed?
-          if reply.unauthorized? && auth.has_key?[database]
+          if reply.unauthorized? && auth.has_key?(database)
             # If we got here, most likely this is the case of Moped
             # authenticating successfully against the node originally, but the
             # node has been reset or gone down and come back up. The most


### PR DESCRIPTION
This causes `ArgumentError: wrong number of arguments(0 for 1)` when a failover occurs

Sample backtrace (with Moped 1.2.2):

```
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/node.rb:343 • has_key?
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/node.rb:343 • block in query
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/node.rb:532 • []
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/node.rb:532 • block (3 levels) in flush
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/node.rb:531 • map
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/node.rb:531 • block (2 levels) in flush
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/node.rb:123 • ensure_connected
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/node.rb:527 • block in flush
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/node.rb:542 • logging
config/initializers/moped_newrelic_instrumentation.rb:48 • block in logging_with_newrelic
vendor/bundle/ruby/1.9.1/gems/newrelic_rpm-3.4.2.1/lib/new_relic/agent/method_tracer.rb:242 • trace_execution_scoped
config/initializers/moped_newrelic_instrumentation.rb:45 • logging_with_newrelic
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/node.rb:526 • flush
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/node.rb:515 • process
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/node.rb:341 • query
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/cursor.rb:116 • block in load_docs
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/session/context.rb:109 • block in with_node
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/cluster.rb:150 • block in with_primary
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/node.rb:168 • ensure_primary
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/cluster.rb:149 • with_primary
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/session/context.rb:108 • with_node
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/cursor.rb:115 • load_docs
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/cursor.rb:25 • each
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/query.rb:77 • each
vendor/bundle/ruby/1.9.1/gems/moped-1.2.2/lib/moped/query.rb:77 • each
vendor/bundle/ruby/1.9.1/gems/mongoid-3.0.6/lib/mongoid/contextual/mongo.rb:133 • block in each
vendor/bundle/ruby/1.9.1/gems/mongoid-3.0.6/lib/mongoid/contextual/mongo.rb:603 • selecting
vendor/bundle/ruby/1.9.1/gems/mongoid-3.0.6/lib/mongoid/contextual/mongo.rb:132 • each
vendor/bundle/ruby/1.9.1/gems/mongoid-3.0.6/lib/mongoid/contextual.rb:18 • each
vendor/bundle/ruby/1.9.1/gems/mongoid-3.0.6/lib/mongoid/criteria.rb:619 • entries
vendor/bundle/ruby/1.9.1/gems/mongoid-3.0.6/lib/mongoid/criteria.rb:619 • from_database
vendor/bundle/ruby/1.9.1/gems/mongoid-3.0.6/lib/mongoid/criteria.rb:310 • multiple_from_map_or_db
vendor/bundle/ruby/1.9.1/gems/mongoid-3.0.6/lib/mongoid/criteria.rb:176 • execute_or_raise
vendor/bundle/ruby/1.9.1/gems/mongoid-3.0.6/lib/mongoid/criteria.rb:243 • find
vendor/bundle/ruby/1.9.1/gems/mongoid-3.0.6/lib/mongoid/finders.rb:61 • find
app/controllers/application_controller.rb:37 • current_user
```
