### PR TITLE
New Linger Socket Option doesn't work in JRuby

### DIFF
--- a/lib/moped/sockets/connectable.rb
+++ b/lib/moped/sockets/connectable.rb
@@ -104,7 +104,12 @@ module Moped
           Timeout::timeout(timeout) do
             sock = new(host, port)
             sock.set_encoding('binary')
-            sock.setsockopt(Socket::Option.linger(false, 0))
+            if RUBY_PLATFORM == 'java'
+              linger = [0, 0].pack("ii")
+              sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER, linger)
+            else
+              sock.setsockopt(Socket::Option.linger(false, 0))
+            end
             sock.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
             sock
           end


### PR DESCRIPTION
I just happened to be testing out something in moped-head, and noticed this.  Bunches of specs were failing in JRuby 1.6.7.2 & 1.6.8.

From what I can tell, this commit is the correct method for setting the linger option in JRuby since the Socket::Option class doesn't exist.

I tested against all the specs other than cluster & authenticate, and it looks good to me.

-Aaron
