### PR TITLE
call OpenSSL::SSL::SSLSocket#connect

### DIFF
--- a/lib/moped/sockets/ssl.rb
+++ b/lib/moped/sockets/ssl.rb
@@ -23,6 +23,7 @@ module Moped
         handle_socket_errors do
           @socket = TCPSocket.new(host, port)
           super(socket)
+          connect
         end
       end
 


### PR DESCRIPTION
When talking to Mongo SSL servers it seems to be necessary to call #connect on our OpenSSL::SSL::SSLSocket instances to make the SSL key exchange stuff start happening.  Otherwise the peer closes the connection and we get `Moped::Errors::ConnectionFailure: Could not connect to any secondary or primary nodes for replica set`

The cluster I'm connecting to is Mongo 2.2.1-rc1-pre-, built with `/usr/bin/scons --ssl --prefix=/usr/local/stow/mongo install` - I don't know if this should make a difference, it does seem weird that nobody else has noticed this.

Transcript from irb

```
dbarlow@macdbarlow ~/src/moped (master=) $ irb -I ./lib -r moped
Loading /Users/dbarlow/.irbrc...
1.9.3p194 :001 > session=Moped::Session.new(["10.10.2.13:27017"], ssl: true)
 => #<Moped::Session:0x007ff9aa1ed0b0 @cluster=<Moped::Cluster nodes=[<Moped::Node resolved_address="10.10.2.13:27017">]>, @context=#<Moped::Session::Context:0x007ff9aa1eccf0 @session=#<Moped::Session:0x007ff9aa1ed0b0 ...>>, @options={:ssl=>true, :consistency=>:eventual}> 
1.9.3p194 :002 > session.with(database:'chopin_development').tap{|s| s.login('chopin','is hard, lets do math')}.collections.map(&:name)
Moped::Errors::ConnectionFailure: Could not connect to any secondary or primary nodes for replica set <Moped::Cluster nodes=[<Moped::Node resolved_address="10.10.2.13:27017">]>
    from /Users/dbarlow/src/moped/lib/moped/cluster.rb:205:in `with_secondary'
    from /Users/dbarlow/src/moped/lib/moped/cluster.rb:202:in `with_secondary'
    from /Users/dbarlow/src/moped/lib/moped/session/context.rb:104:in `with_node'
    from /Users/dbarlow/src/moped/lib/moped/cursor.rb:115:in `load_docs'
    from /Users/dbarlow/src/moped/lib/moped/cursor.rb:25:in `each'
    from /Users/dbarlow/src/moped/lib/moped/query.rb:77:in `each'
    from /Users/dbarlow/src/moped/lib/moped/query.rb:77:in `each'
    from /Users/dbarlow/src/moped/lib/moped/database.rb:58:in `map'
    from /Users/dbarlow/src/moped/lib/moped/database.rb:58:in `collection_na    class SSL < OpenSSL::SSL::SSLSocket
mes'
    from /Users/dbarlow/src/moped/lib/moped/database.rb:44:in `collections'
    from /Users/dbarlow/src/moped/lib/moped/session.rb:67:in `collections'
    from (irb):2
    from /Users/dbarlow/.rvm/rubies/ruby-1.9.3-p194/bin/irb:16:in `<main>'
```
