### PR TITLE
Correcting findAndModify with upsert for Mongo >= 2.2.0

### DIFF
--- a/lib/moped/query.rb
+++ b/lib/moped/query.rb
@@ -207,7 +207,7 @@ module Moped
       end
 
       # Keeping moped compatibility with mongodb >= 2.2.0-rc0
-      options[:upsert] && !result ? [] : result
+      options[:upsert] && !result ? {} : result
     end
 
     # Remove a single document matching the query's selector.

--- a/spec/moped/query_spec.rb
+++ b/spec/moped/query_spec.rb
@@ -148,6 +148,7 @@ describe Moped::Query do
               end
 
               it "returns an empty hash" do
+                result.should be_kind_of(Hash)
                 result.should be_empty
               end
 


### PR DESCRIPTION
`find_and_modify` with upserts is broken in Mongoid for Mongo >= 2.2.0 due to the findAndModify change returning nil instead of {}. It seems like you made a typo, returning [] instead of {}. The spec for this just asserted that the result should be_empty, which [] responds to affirmatively.

This pull request updates both.
