### PR TITLE
Include arbiters in list of nodes to disconnect

### DIFF
--- a/lib/moped/cluster.rb
+++ b/lib/moped/cluster.rb
@@ -28,7 +28,7 @@ module Moped
     #
     # @since 1.2.0
     def disconnect
-      nodes.each { |node| node.disconnect } and true
+      nodes(include_arbiters: true).each { |node| node.disconnect } and true
     end
 
     # Get the interval at which a node should be flagged as down before
@@ -117,7 +117,7 @@ module Moped
     # @return [ Array<Node> ] the list of available nodes.
     #
     # @since 1.0.0
-    def nodes
+    def nodes(opts = {})
       current_time = Time.new
       down_boundary = current_time - down_interval
       refresh_boundary = current_time - refresh_interval
@@ -133,7 +133,7 @@ module Moped
 
       # Now return all the nodes that are available and participating in the
       # replica set.
-      available.reject { |node| node.down? || node.arbiter? }
+      available.reject { |node| node.down? || (!opts[:include_arbiters] && node.arbiter?) }
     end
 
     # Refreshes information for each of the nodes provided. The node list


### PR DESCRIPTION
As far as I can see, arbiters don't get disconnected when calling Session.disconnect. I have applied this patch to the version of Moped I'm running on my cluster (2 full members, 1 arbiter) and it has fixed problems with the arbiter running out of connections. Previously the arbiter would regularly max out at 819 connections (not sure where that number comes from) and pull down the whole cluster, but now it sits at around 80-90.

I realise there aren't any tests and this patch may not be the best way to solve the problem, I was just hoping to start a discussion, no hard feelings if this patch doesn't get pulled.  :)
