### PR TITLE
[BUG FIX] replica set reconfiguration handled gracefully

### DIFF
--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -133,7 +133,14 @@ module Moped
           raise Errors::ReplicaSetReconfigured
         end
         raise
-      rescue Errors::OperationFailure, Errors::AuthenticationFailure, Errors::CursorNotFound
+      rescue Errors::OperationFailure => e
+        # We might have a replica set change with:
+        # "failed with error 10054: "not master"
+        if e.details['code'] == 10054
+          raise Errors::ReplicaSetReconfigured
+        end
+        raise
+      rescue Errors::AuthenticationFailure, Errors::CursorNotFound
         # These exceptions are "expected" in the normal course of events, and
         # don't necessitate disconnecting.
         raise


### PR DESCRIPTION
Two commits:

```
[BUG FIX] replica set reconfiguration handled gracefully for updates

It only with when using safe: true, otherwise data gets lost...

Stack trace:
  Moped::Errors::OperationFailure: The operation: #<Moped::Protocol::Command
    @length=82
    @request_id=29
    @response_to=0
    @op_code=2004
    @flags=[]
    @full_collection_name="sniper_development.$cmd"
    @skip=0
    @limit=-1
    @selector={:getlasterror=>1, :safe=>true}
    @fields=nil>
  failed with error 10054: "not master"
```

---

```
[BUG FIX] replica set reconfiguration handled gracefully for queries

When using consistency: strong

Stack trace when this happen:
  Moped::Errors::QueryFailure: The operation: #<Moped::Protocol::Query
    @length=97
    @request_id=6
    @response_to=0
    @op_code=2004
    @flags=[]
    @full_collection_name="sniper_development.members"
    @skip=0
    @limit=-1
    @selector={"$query"=>{}, "$orderby"=>{:_id=>1}}
    @fields=nil>
  failed with error 13435: "not master and slaveOk=false"
```
