### PR TITLE
Sane default for safety

### DIFF
--- a/lib/moped/session.rb
+++ b/lib/moped/session.rb
@@ -172,7 +172,7 @@ module Moped
     # @param [ Array ] seeds an of host:port pairs
     # @param [ Hash ] options
     #
-    # @option options [ Boolean ] :safe (false) Ensure writes are persisted.
+    # @option options [ Boolean ] :safe (true) Ensure writes are persisted.
     # @option options [ Hash ] :safe Ensure writes are persisted with the
     #   specified safety level e.g., "fsync: true", or "w: 2, wtimeout: 5".
     # @option options [ Symbol, String ] :database The database to use.
@@ -189,6 +189,7 @@ module Moped
       @context = Context.new(self)
       @options = options
       @options[:consistency] ||= :eventual
+      @options[:safe] = true if @options[:safe].nil?
     end
 
     # Create a new session with +options+ and use new socket connections.


### PR DESCRIPTION
99% of the users care about their data, therefor the default should be to be safe.
Users that don't care about their data can use safe:false.

Related: https://github.com/mongoid/mongoid/pull/2447
