### PR TITLE
Propagate node options to newly discovered nodes

### DIFF
--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -388,7 +388,7 @@ module Moped
         peers.concat(info["passives"]) if info["passives"]
         peers.concat(info["arbiters"]) if info["arbiters"]
 
-        @peers = peers.map { |peer| Node.new(peer) }
+        @peers = peers.map { |peer| Node.new(peer, options) }
         @primary, @secondary = primary, secondary
         @arbiter = info["arbiterOnly"]
         @passive = info["passive"]


### PR DESCRIPTION
When a node probes the replicaset information of a node, it may create new Node objects from the list of nodes the server returns.  The Node's @options should be passed to the new node as well (for instance, the ssl config variable).
