### PR TITLE
Use 16-bit hash of process id and thread object_id as pid part of BSON

### DIFF
--- a/lib/moped/bson/object_id.rb
+++ b/lib/moped/bson/object_id.rb
@@ -111,7 +111,8 @@ module Moped
 
         # Generate object id data for a given time using the provided +counter+.
         def generate(time, counter = 0)
-          [time, @machine_id, Process.pid, counter << 8].pack("N NX lXX NX")
+          process_thread_id = "#{Process.pid}#{Thread.current.object_id}".hash % 0xFFFF
+          [time, @machine_id, process_thread_id, counter << 8].pack("N NX lXX NX")
         end
       end
 


### PR DESCRIPTION
This fixes #99 .
