### PR TITLE
Recover gracefully from Step Down

### DIFF
--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -140,8 +140,9 @@ module Moped
         raise
       rescue Errors::OperationFailure => e
         # We might have a replica set change with:
-        # "failed with error 10054: "not master"
-        if e.details['code'] == 10054
+        # MongoDB uses 3 different error codes for "not master", [10054, 10056, 10058]
+        # thus it is easier to capture the "err"
+        if e.details["err"] == "not master" 
           raise Errors::ReplicaSetReconfigured
         end
         raise


### PR DESCRIPTION
When the Primary node would step down, we were seeing the following errors:

```
Moped::Errors::OperationFailure: The operation: #<Moped::Protocol::Command
  @length=69
  @request_id=7
  @response_to=0
  @op_code=2004
  @flags=[]
  @full_collection_name="my_db.$cmd"
  @skip=0
  @limit=-1
  @selector={:getlasterror=>1, :safe=>true}
  @fields=nil>
failed with error 10058: "not master"

See https://github.com/mongodb/mongo/blob/master/docs/errors.md
```

However, code "10058" was not being rescued properly in the node.  When looking at the mongodb code, I found other error codes.  Instead of capturing error codes, now capturing "err" message.
