### PR TITLE
Give a better response when a poor URI is provided

### DIFF
--- a/lib/moped/errors.rb
+++ b/lib/moped/errors.rb
@@ -11,6 +11,9 @@ module Moped
     # Raised when a database name is invalid.
     class InvalidDatabaseName < StandardError; end
 
+    # Raised when a Mongo URI is invalid.
+    class InvalidMongoURI < StandardError; end
+
     # Raised when providing an invalid string from an object id.
     class InvalidObjectId < StandardError
 

--- a/lib/moped/mongo_uri.rb
+++ b/lib/moped/mongo_uri.rb
@@ -63,7 +63,39 @@ module Moped
     # @since 1.3.0
     def initialize(string)
       @match = string.match(URI)
+      invalid_uri!(string) unless @match
     end
+
+    # Raise a human readable error when improper URI provided
+    #
+    # @example Raise error and provide guidance on invalid URI
+    #   MongoUri.invalid!(uri)
+    #
+    # @param [ String ] Invalid string
+    #
+    # @since 1.3.1
+    def invalid_uri!(string)
+      msg = %{
+The given connection string is invalid:
+  #{string}
+
+MongoDB connection strings must be of the format:
+  mongodb://host:port/database
+
+For authentication, include username and password before host:
+  mongodb://username:password@host:port/database
+
+For Replica Sets, include multiple host:port entries:
+  mongodb://host:port,host2:port2/database
+
+For options, use query string syntax with the option value:
+  mongodb://host:port/database?safe=true&max_retries=30&timeout=5
+      }
+
+      raise Errors::InvalidMongoURI, msg
+    end
+
+
 
     # Get the options provided in the URI.
     # @example Get the options

--- a/spec/moped/mongo_uri_spec.rb
+++ b/spec/moped/mongo_uri_spec.rb
@@ -10,6 +10,10 @@ describe Moped::MongoUri do
     "mongodb://localhost:27017,localhost:27017/mongoid_test"
   end
 
+  let(:invalid) do
+    "invalid://uri/test"
+  end
+
   describe "#database" do
 
     let(:uri) do
@@ -43,6 +47,16 @@ describe Moped::MongoUri do
       it "returns an array with 2 nodes" do
         uri.hosts.should eq([ "localhost:27017", "localhost:27017" ])
       end
+    end
+  end
+
+  describe "#invalid" do
+    let(:uri) do
+      described_class.new(invalid)
+    end
+
+    it "raises informative error" do
+      lambda { uri }.should raise_exception(Moped::Errors::InvalidMongoURI)
     end
   end
 


### PR DESCRIPTION
I was bitten by the URI feature.  I entered an improper URI and was greeted with:

```
/Users/chris/Projects/moped/lib/moped/mongo_uri.rb:53:in `hosts': undefined method `[]' for nil:NilClass (NoMethodError)
  from /Users/chris/Projects/moped/lib/moped/mongo_uri.rb:134:in `moped_arguments'
  from /Users/chris/Projects/moped/lib/moped/session.rb:332:in `connect'
  from -e:1:in `<main>'
```

With this pull, when you enter an invalid MongoURI, it fails quickly and gracefully:

```
/Users/chris/Projects/moped/lib/moped/mongo_uri.rb:95:in `invalid_uri!':  (Moped::Errors::InvalidMongoURI)
The given connection string is invalid:
  mongo://localasdf

MongoDB connection strings must be of the format:
  mongodb://host:port/database

For authentication, include username and password before host:
  mongodb://username:password@host:port/database

For Replica Sets, include multiple host:port entries:
  mongodb://host:port,host2:port2/database

For options, use query string syntax with the option value:
  mongodb://host:port/database?safe=true&max_retries=30&timeout=5

  from /Users/chris/Projects/moped/lib/moped/mongo_uri.rb:66:in `initialize'
  from /Users/chris/Projects/moped/lib/moped/session.rb:331:in `new'
  from /Users/chris/Projects/moped/lib/moped/session.rb:331:in `connect'
  from -e:1:in `<main>'
```

I was a little verbose on the help just to give full knowledge of MongoDB syntax.

I choose to include the given MongoDB URI.  I find it often helps with debugging; however, it may contain sensitive information.  I removed the most offensive portion of the URI (the password).

Please, scale back the message as you wish.
