### PR TITLE
Accept a batch_size in the query and use it in the cursor.

### DIFF
--- a/lib/moped/cursor.rb
+++ b/lib/moped/cursor.rb
@@ -41,10 +41,18 @@ module Moped
     #
     # @since 1.0.0
     def get_more
-      reply = @node.get_more @database, @collection, @cursor_id, @limit
+      reply = @node.get_more @database, @collection, @cursor_id, request_limit
       @limit -= reply.count if limited?
       @cursor_id = reply.cursor_id
       reply.documents
+    end
+
+    def request_limit
+      if @limit <= 0
+        @batch_size
+      else
+        [@limit, @batch_size].min
+      end
     end
 
     # Initialize the new cursor.
@@ -66,11 +74,12 @@ module Moped
       @cursor_id = 0
       @limit = query_operation.limit
       @limited = @limit > 0
+      @batch_size = query_operation.batch_size || @limit
 
       @options = {
         request_id: query_operation.request_id,
         flags: query_operation.flags,
-        limit: query_operation.limit,
+        limit: request_limit,
         skip: query_operation.skip,
         fields: query_operation.fields
       }

--- a/lib/moped/protocol/query.rb
+++ b/lib/moped/protocol/query.rb
@@ -78,6 +78,8 @@ module Moped
       # @return [String, Symbol] the collection to query
       attr_reader :collection
 
+      attr_accessor :batch_size
+
       # Create a new query command.
       #
       # @example
@@ -109,6 +111,7 @@ module Moped
         @limit                = options[:limit]
         @skip                 = options[:skip]
         @fields               = options[:fields]
+        @batch_size           = options[:batch_size]
       end
 
       def log_inspect
@@ -122,6 +125,7 @@ module Moped
         fields << ["limit=%s", limit.inspect]
         fields << ["skip=%s", skip.inspect]
         fields << ["fields=%s", self.fields.inspect]
+        fields << ["batch_size=%s", self.batch_size.inspect]
         f, v = fields.transpose
         f.join(" ") % v
       end

--- a/lib/moped/query.rb
+++ b/lib/moped/query.rb
@@ -173,6 +173,11 @@ module Moped
       self
     end
 
+    def batch_size(batch_size)
+      operation.batch_size = batch_size
+      self
+    end
+
     # Execute a $findAndModify on the query.
     #
     # @example Find and modify a document, returning the original.


### PR DESCRIPTION
We created branches in Moped and Mongoid that make the cursor respect the batch size, but we're not sure how to best test that, as to the client the usage of a batch size should be transparent.

Maybe someone has a good idea how to best test this?

The pull request for mongoid is here:
https://github.com/mongoid/mongoid/pull/2609
