### PR TITLE
Fix queries being sent to RECOVERING nodes within a replica set

### DIFF
--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -417,7 +417,7 @@ module Moped
           if !primary && Threaded.executing?(:ensure_primary)
             raise Errors::ReplicaSetReconfigured, "#{inspect} is no longer the primary node."
           elsif !primary && !secondary
-            # not primary or secondary so# mark it as down, since it's probably
+            # not primary or secondary so mark it as down, since it's probably
             # a recovering node withing the replica set
             down!
           end


### PR DESCRIPTION
This pull requests fixes the issue I described in my last comment at:

  https://github.com/mongoid/moped/issues/115

It marks the node as down if it's neither a primary or secondary node, a condition which occurs when a node within a replica set is in the RECOVERING state.

FWIW, I don't know if this is the best solution but it works for me.
