### PR TITLE
Allow using readable index types

### DIFF
--- a/spec/moped/indexes_spec.rb
+++ b/spec/moped/indexes_spec.rb
@@ -32,6 +32,34 @@ describe Moped::Indexes do
         index["dropDups"].should be_true
       end
     end
+
+    context "when called with :asc index type" do
+      it "creates an ascending index" do
+        indexes.create({name: :asc})
+        indexes[name: 1].should_not be_nil
+      end
+    end
+
+    context "when called with :desc index type" do
+      it "creates a descending index" do
+        indexes.create({name: :desc})
+        indexes[name: -1].should_not be_nil
+      end
+    end
+
+    context "when called with :ascending index type" do
+      it "creates an ascending index" do
+        indexes.create({name: :ascending})
+        indexes[name: 1].should_not be_nil
+      end
+    end
+
+    context "when called with :descending index type" do
+      it "creates a descending index" do
+        indexes.create({name: :descending})
+        indexes[name: -1].should_not be_nil
+      end
+    end
   end
 
   describe "#drop" do
@@ -39,6 +67,13 @@ describe Moped::Indexes do
       it "drops the index" do
         indexes.create name: 1
         indexes.drop(name: 1).should be_true
+      end
+
+      context "when key has :asc index type" do
+        it "drops the index" do
+          indexes.create name: :asc
+          indexes.drop(name: :asc).should be_true
+        end
       end
     end
 


### PR DESCRIPTION
Hi,

This pull request adds the option to provide human readable arguments to ```Moped::Indexes``` methods.

This will enable the following code in Mongoid models:
```ruby
class PullRequest
  include Mongoid::Document
  field :useless_level, type: String

  index useless_level: :asc
end
```

Let me know if you like where it's going so I can make the required changes in documentation both here and in mongoid.

Thanks!