### PR TITLE
IOError connection timed out, not handled and so connection isnt reestablished

### DIFF
--- a/lib/moped/sockets/connectable.rb
+++ b/lib/moped/sockets/connectable.rb
@@ -106,6 +106,11 @@ module Moped
               sock = new(host, port)
               sock.set_encoding('binary')
               sock.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
+
+              timeout_val = [timeout, 0].pack("l_2")
+              sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_RCVTIMEO, timeout_val)
+              sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDTIMEO, timeout_val)
+              
               sock
             end
           rescue Timeout::Error


### PR DESCRIPTION
I've had this happen to me a number of times on JRuby 1.7.1 on a Rails app running with Puma.

backtrace: https://gist.github.com/4512402

on a read to the socket, sometimes an IOError is raised (https://github.com/mongoid/moped/blob/master/lib/moped/sockets/connectable.rb#L45) .. but the exception isn't caught, and so a connectionfailure is never raised and moped doesn't go through the reconnecting stage.
