### PR TITLE
Don't try to blindly reconnect on connections failures

### DIFF
--- a/lib/moped/connection.rb
+++ b/lib/moped/connection.rb
@@ -198,7 +198,7 @@ module Moped
     #
     # @since 1.3.0
     def with_connection
-      connect if @sock.nil? || !@sock.alive?
+      connect if @sock.nil?
       yield @sock
     end
   end


### PR DESCRIPTION
On a replica set, when the master changes, the old master disconnects
all clients. This mean we have to trigger a cluster refresh on every
disconnect and don't try not to blindly reconnect.

In order to do that we propagate exceptions from `Node#ensure_connected`
and `Connection#with_connection`.

Before that, a non-safe session never caught up with a failover and all
subsequent inserts were silently lost.

This can be considered a work in progress as it breaks some tests and change some core stuff like node auto reconnecting. I have the feeling that the node is not the correct spot to handle connection errors, and those should be handled at the cluster level.

This is because a disconnect carries information about a possible cluster failover according to the spec (http://docs.mongodb.org/manual/applications/replication/#behavior).
