### PR TITLE
Actually test on Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 bundler_args: --without development
 rvm:
   - 1.9.3
+  - 2.0.0
   - jruby
 jdk:
   - oraclejdk7


### PR DESCRIPTION
The README states the Moped is tested on Ruby 2.0, but it isn’t actually (at least not on CI). This remedies that.
