### PR TITLE
Adds checking for the word 'unauthorized' to the unauthorized check. #171

### DIFF
--- a/lib/moped/protocol/reply.rb
+++ b/lib/moped/protocol/reply.rb
@@ -110,7 +110,10 @@ module Moped
       # @since 1.2.10
       def unauthorized?
         result = documents[0]
-        result && (UNAUTHORIZED.include?(result["code"]) || UNAUTHORIZED.include?(result["assertionCode"]))
+        return false if result.nil?
+
+        err = result["err"] || result["errmsg"] || result["$err"]
+        UNAUTHORIZED.include?(result["code"]) || UNAUTHORIZED.include?(result["assertionCode"]) || (err && err =~ /unauthorized/)
       end
 
       class << self

--- a/spec/moped/protocol/reply_spec.rb
+++ b/spec/moped/protocol/reply_spec.rb
@@ -251,6 +251,24 @@ describe Moped::Protocol::Reply do
       end
     end
 
+    context "when the error message says unauthorized" do
+      let(:error) do
+        { "ok" => 0, "err" => "unauthorized", "assertionCode" => 2004 }
+      end
+
+      let(:reply) do
+        described_class.new
+      end
+
+      before do
+        reply.documents = [ error ]
+      end
+
+      it "returns true" do
+        reply.should be_unauthorized
+      end
+    end
+
     context "when no auth errors exist" do
 
       let(:error) do


### PR DESCRIPTION
Looking at the error message I've been having, `failed with error "unauthorized"` and then looking at errors.rb, `#error_message` it seems like there was neither a code nor an assertionCode in the response.

As such, I decided to regex the error message for the word unauthorized. A bit shady perhaps, but I'm getting this error frequently and sporadically in production and staging after upgrading to 2.4.1. :-\
