### PR TITLE
Set process_thread_id variable based on the RUBY_ENGINE variable

### DIFF
--- a/lib/moped/bson/object_id.rb
+++ b/lib/moped/bson/object_id.rb
@@ -290,7 +290,7 @@ module Moped
 
         # Generate object id data for a given time using the provided +counter+.
         def generate(time, counter = 0)
-          process_thread_id = "#{Process.pid}#{Thread.current.object_id}".hash % 0xFFFF
+          process_thread_id = RUBY_ENGINE == 'jruby' ? "#{Process.pid}#{Thread.current.object_id}".hash % 0xFFFF : Process.pid
           [time, @machine_id, process_thread_id, counter << 8].pack("N NX lXX NX")
         end
       end


### PR DESCRIPTION
The current logic to set the process_thread_id based on the hash of pid and thread id breaks up in a multi process environment like unicorn.
