### PR TITLE
Logging of connection attempts (1.4.0-stable)

### DIFF
--- a/lib/moped/cluster.rb
+++ b/lib/moped/cluster.rb
@@ -217,14 +217,14 @@ module Moped
       if retries > 0
         # We couldn't find a primary node, so refresh the list and try again.
         if logger = Moped.logger
-          logger.warn " MOPED: Could not connect to primary node for replica set #{inspect} -- retrying"
+          logger.warn "MOPED WARNING: Could not connect to primary node for replica set #{inspect} -- retrying"
         end
         sleep(retry_interval)
         refresh
         with_primary(retries - 1, &block)
       else
         if logger = Moped.logger
-          logger.error " MOPED: Could not connect to primary node for replica set #{inspect}"
+          logger.error "MOPED ERROR: Could not connect to primary node for replica set #{inspect}"
         end
         raise(
           Errors::ConnectionFailure,
@@ -256,7 +256,7 @@ module Moped
           return yield node.apply_auth(auth)
         rescue Errors::ConnectionFailure
           if logger = Moped.logger
-            logger.warn " MOPED: Could not connect to secondary node #{node.inspect} for replica set #{inspect}"
+            logger.warn "MOPED WARNING: Could not connect to secondary node #{node.inspect} for replica set #{inspect}"
           end
           # That node's no good, so let's try the next one.
           next
@@ -267,14 +267,14 @@ module Moped
         # We couldn't find a secondary or primary node, so refresh the list and
         # try again.
         if logger = Moped.logger
-          logger.warn " MOPED: Could not connect to any secondary or primary nodes for replica set #{inspect}"
+          logger.warn "MOPED WARNING: Could not connect to any secondary or primary nodes for replica set #{inspect}"
         end
         sleep(retry_interval)
         refresh
         with_secondary(retries - 1, &block)
       else
         if logger = Moped.logger
-          logger.error " MOPED: Could not connect to any secondary or primary nodes for replica set #{inspect}"
+          logger.error "MOPED ERROR: Could not connect to any secondary or primary nodes for replica set #{inspect}"
         end
         raise(
           Errors::ConnectionFailure,


### PR DESCRIPTION
We have found it useful to have more verbose logs when things go wrong, in order to be able to respond when the first connection attempt fails, instead of having to wait for all retries. 

This pull request adds some more logging to the 1.4.0-stable branch.
