### PR TITLE
Logging of connection attempts (master)

### DIFF
--- a/lib/moped/read_preference/selectable.rb
+++ b/lib/moped/read_preference/selectable.rb
@@ -65,10 +65,18 @@ module Moped
           block.call
         rescue Errors::ConnectionFailure => e
           if retries > 0
+            if logger = Moped.logger
+              logger.warning "MOPED WARNING: Connection error in #{inspect}, retrying! Error: #{e}"
+            end
+
             sleep(cluster.retry_interval)
             cluster.refresh
             with_retry(cluster, retries - 1, &block)
           else
+            if logger = Moped.logger
+              logger.error "MOPED ERROR: Connection error in #{inspect}, not retrying any more. Error: #{e}"
+            end
+
             raise e
           end
         end


### PR DESCRIPTION
We have found it useful to have more verbose logs when things go wrong, in order to be able to respond when the first connection attempt fails, instead of having to wait for all retries. 

This pull request adds some more logging to the master branch.
