### PR TITLE
Fixing regression around not authorized error messages.

### DIFF
--- a/lib/moped/protocol/reply.rb
+++ b/lib/moped/protocol/reply.rb
@@ -114,7 +114,7 @@ module Moped
         err = error_message(result)
         UNAUTHORIZED.include?(result["code"]) ||
           UNAUTHORIZED.include?(result["assertionCode"]) ||
-          (err && err =~ /unauthorized/)
+          (err && (err =~ /unauthorized/ || err =~ /not authorized/))
       end
 
       class << self

--- a/spec/moped/protocol/reply_spec.rb
+++ b/spec/moped/protocol/reply_spec.rb
@@ -269,6 +269,24 @@ describe Moped::Protocol::Reply do
       end
     end
 
+    context "when the error message says not authorized" do
+      let(:error) do
+        { "ok" => 0, "err" => "not authorized for query on", "assertionCode" => 2004 }
+      end
+
+      let(:reply) do
+        described_class.new
+      end
+
+      before do
+        reply.documents = [ error ]
+      end
+
+      it "returns true" do
+        reply.should be_unauthorized
+      end
+    end
+
     context "when no auth errors exist" do
 
       let(:error) do


### PR DESCRIPTION
Hey @durran, it seems that this regressed in 1.5.0-stable. This code exists in 1.4.0-stable and master but not in 1.5.0-stable -- I just updated my staging environment with 1.5.0 yesterday and this happened again (see https://github.com/mongoid/moped/pull/174 where I first added it).
