### PR TITLE
Remove returns that result in localjump errors when nodes are not authorized

### DIFF
--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -94,7 +94,7 @@ module Moped
         if reply.command_failure?
           if reply.unauthorized? && auth.has_key?(database)
             login(database, *auth[database])
-            return command(database, cmd, options)
+            result = command(database, cmd, options)
           else
             raise Errors::OperationFailure.new(operation, result)
           end
@@ -377,7 +377,7 @@ module Moped
             # connection. In this case we need to requthenticate and try again,
             # otherwise we'll just raise the error to the user.
             login(database, *auth[database])
-            return query(database, collection, selector, options)
+            reply = query(database, collection, selector, options)
           else
             raise Errors::QueryFailure.new(operation, reply.documents.first)
           end


### PR DESCRIPTION
referencing mongoid/moped#203
