### PR TITLE
add timeout to address resolve

### DIFF
--- a/lib/moped.rb
+++ b/lib/moped.rb
@@ -3,6 +3,7 @@ require "logger"
 require "stringio"
 require "monitor"
 require "timeout"
+require 'resolv'
 require "bson"
 require "optionable"
 require "moped/errors"

--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -253,7 +253,6 @@ module Moped
     #
     # @since 1.0.0
     def initialize(address, options = {})
-      @address = Address.new(address)
       @options = options
       @down_at = nil
       @refreshed_at = nil
@@ -261,6 +260,7 @@ module Moped
       @primary = nil
       @secondary = nil
       @instrumenter = options[:instrumenter] || Instrumentable::Log
+      @address = Address.new(address, timeout)
       @address.resolve(self)
     end
 

--- a/spec/moped/address_spec.rb
+++ b/spec/moped/address_spec.rb
@@ -7,7 +7,7 @@ describe Moped::Address do
     context "when a port is provided" do
 
       let(:address) do
-        described_class.new("127.0.0.1:27017")
+        described_class.new("127.0.0.1:27017", 2)
       end
 
       it "sets the original address" do
@@ -26,7 +26,7 @@ describe Moped::Address do
     context "when no port is provided" do
 
       let(:address) do
-        described_class.new("localhost")
+        described_class.new("localhost", 2)
       end
 
       it "sets the original address" do
@@ -52,7 +52,7 @@ describe Moped::Address do
       end
 
       let(:address) do
-        described_class.new("127.0.0.1:27017")
+        described_class.new("127.0.0.1:27017", 2)
       end
 
       before do
@@ -75,7 +75,7 @@ describe Moped::Address do
       end
 
       let(:address) do
-        described_class.new("localhost:27017")
+        described_class.new("localhost:27017", 2)
       end
 
       before do
@@ -98,7 +98,7 @@ describe Moped::Address do
       end
 
       let(:address) do
-        described_class.new("notahost:27017")
+        described_class.new("notahost:27017", 1)
       end
 
       let!(:resolved) do


### PR DESCRIPTION
I am not 100% sure, but I guess having a timeout on DNS resolve make sense. Also I had to stop using `Socket.getaddrinfo` in order to make the timeout block to work.

@durran Let me know if you see any problem with the solution.
