### PR TITLE
Make the connection pool use a Queue instead of a stack

### DIFF
--- a/lib/moped/connection/pool.rb
+++ b/lib/moped/connection/pool.rb
@@ -11,7 +11,7 @@ module Moped
       POOL_SIZE = 5
 
       # The default timeout for getting connections from the queue.
-      TIMEOUT = 0.25
+      TIMEOUT = 0.5
 
       # @!attribute host
       #   @return [ String ] The host the pool is for.
@@ -81,7 +81,7 @@ module Moped
         @mutex = Mutex.new
         @resource = ConditionVariable.new
         @pinned = {}
-        @unpinned = Queue.new(max_size) do
+        @unpinned = Queue.new(max_size, timeout) do
           Connection.new(host, port, options[:timeout] || Connection::TIMEOUT, options)
         end
         reaper.start
@@ -179,7 +179,7 @@ module Moped
 
       def next_connection
         reap if saturated?
-        unpinned.pop(timeout)
+        unpinned.shift
       end
 
       def saturated?

--- a/spec/moped/connection/pool_spec.rb
+++ b/spec/moped/connection/pool_spec.rb
@@ -262,7 +262,7 @@ describe Moped::Connection::Pool do
       end
 
       it "returns the default" do
-        expect(pool.timeout).to eq(0.25)
+        expect(pool.timeout).to eq(Moped::Connection::Pool::TIMEOUT)
       end
     end
   end

--- a/spec/moped/connection/queue_spec.rb
+++ b/spec/moped/connection/queue_spec.rb
@@ -5,7 +5,7 @@ describe Moped::Connection::Queue do
   describe "#empty?" do
 
     let(:queue) do
-      described_class.new(1) do
+      described_class.new(1, 0.5) do
         Moped::Connection.new("127.0.0.1", 27017, 5)
       end
     end
@@ -20,7 +20,7 @@ describe Moped::Connection::Queue do
     context "when the queue has no connections" do
 
       before do
-        queue.pop
+        queue.shift
       end
 
       it "returns true" do
@@ -32,7 +32,7 @@ describe Moped::Connection::Queue do
   describe "#initialize" do
 
     let(:queue) do
-      described_class.new(2) do
+      described_class.new(2, 0.5) do
         Moped::Connection.new("127.0.0.1", 27017, 5)
       end
     end
@@ -42,10 +42,10 @@ describe Moped::Connection::Queue do
     end
   end
 
-  describe "#pop" do
+  describe "#shift" do
 
     let(:queue) do
-      described_class.new(1) do
+      described_class.new(1, 0.5) do
         Moped::Connection.new("127.0.0.1", 27017, 5)
       end
     end
@@ -53,7 +53,7 @@ describe Moped::Connection::Queue do
     context "when a connection is available" do
 
       let(:popped) do
-        queue.pop
+        queue.shift
       end
 
       it "returns the connection" do
@@ -64,7 +64,7 @@ describe Moped::Connection::Queue do
     context "when a connection is not available" do
 
       before do
-        queue.pop
+        queue.shift
       end
 
       context "when a connection is pushed in the timeout period" do
@@ -81,14 +81,14 @@ describe Moped::Connection::Queue do
         end
 
         it "returns the connection" do
-          expect(queue.pop(2)).to equal(connection)
+          expect(queue.shift).to equal(connection)
         end
       end
 
       context "when no connection is pushed in the timeout period" do
 
         it "raises an error" do
-          expect { queue.pop(1) }.to raise_error(Timeout::Error)
+          expect { queue.shift }.to raise_error(Timeout::Error)
         end
       end
     end
@@ -101,7 +101,7 @@ describe Moped::Connection::Queue do
     end
 
     let(:queue) do
-      described_class.new(1) do
+      described_class.new(1, 0.5) do
         Moped::Connection.new("127.0.0.1", 27017, 5)
       end
     end
@@ -118,7 +118,7 @@ describe Moped::Connection::Queue do
   describe "#size" do
 
     let(:queue) do
-      described_class.new(1) do
+      described_class.new(1, 0.5) do
         Moped::Connection.new("127.0.0.1", 27017, 5)
       end
     end


### PR DESCRIPTION
`Connection::Pool` had a `Queue` inside it, which was not actually a queue. Making it a Queue. :sparkles: 

@durran for review
