### PR TITLE
ConnectionPool checkin should put connection back into the pool

### DIFF
--- a/spec/moped/cluster_spec.rb
+++ b/spec/moped/cluster_spec.rb
@@ -270,7 +270,7 @@ describe Moped::Cluster, replica_set: true do
   context "with down interval" do
 
     let(:cluster) do
-      Moped::Cluster.new(seeds, { down_interval: 5 })
+      Moped::Cluster.new(seeds, { down_interval: 5, pool_size: 1 })
     end
 
     context "and all secondaries are down" do

--- a/spec/moped/connection/pool_spec.rb
+++ b/spec/moped/connection/pool_spec.rb
@@ -28,12 +28,12 @@ describe Moped::Connection::Pool do
           pool.checkin(connection)
         end
 
-        it "keeps the connection pinned" do
-          expect(pinned[Thread.current.object_id]).to equal(connection)
+        it "releases the connection" do
+          expect(pinned[Thread.current.object_id]).to be_nil
         end
 
-        it "does not modify the unpinned connections" do
-          expect(unpinned.size).to eq(1)
+        it "sets to zero the pinned connections" do
+          expect(pinned.size).to eq(0)
         end
 
         it "expires the connection" do
@@ -103,8 +103,13 @@ describe Moped::Connection::Pool do
             pool.checkin(existing)
           end
 
-          it "returns the connection" do
-            expect(pool.checkout).to equal(existing)
+          let(:connection) do
+            pool.checkout
+          end
+
+          it "returns a new connection" do
+            expect(connection).to_not be_nil
+            expect(connection).to_not equal(existing)
           end
         end
 

--- a/spec/moped/node_spec.rb
+++ b/spec/moped/node_spec.rb
@@ -7,7 +7,7 @@ describe Moped::Node, replica_set: true do
   end
 
   let(:node) do
-    Moped::Node.new(replica_set_node.address)
+    Moped::Node.new(replica_set_node.address, pool_size: 1)
   end
 
   describe "#auto_discovering?" do
@@ -105,7 +105,7 @@ describe Moped::Node, replica_set: true do
     context "when the node is auto discovering" do
 
       let(:node) do
-        described_class.new("127.0.0.1:27017")
+        described_class.new("127.0.0.1:27017", pool_size: 1)
       end
 
       before do


### PR DESCRIPTION
(this PR depends on #226 being merged first)

We need to checkin the connection(put back in the pool) after use.
We cannot only depend on the reaper to get rid of connection, as threads could be sleeping or blocked by something else. If we make the connections rotate in the pool, we could have more threads using less connections.

just for an example, other gems are going the same thing:
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L370
https://github.com/zk-ruby/zk/blob/master/lib/zk/pool.rb#L203
https://github.com/mperham/connection_pool/blob/master/lib/connection_pool.rb#L79

[fixes #223]

review @durran 
