### PR TITLE
Retries when there is an auth failure on insert.

### DIFF
--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -585,6 +585,16 @@ module Moped
           connection.write operations
           replies = connection.receive_replies(operations)
 
+          if replies && replies.length > 0
+            replies.each_with_index do |reply, i|
+              operation = operations[i]
+              if reply && reply.unauthorized? && auth.has_key?(operation.database)
+                login(operation.database, *auth[operation.database])
+                flush([ops[i]])
+              end
+            end
+          end
+
           replies.zip(callbacks).map do |reply, callback|
             callback ? callback[reply] : reply
           end.last

--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -93,6 +93,9 @@ module Moped
         result = reply.documents.first
         if reply.command_failure?
           if reply.unauthorized? && auth.has_key?(database)
+            if logger = Moped.logger
+              logger.info {"Received unauthorized reply for command #{cmd} on #{database}: #{reply.documents[0].inspect}"}
+            end
             login(database, *auth[database])
             result = command(database, cmd, options)
           else
@@ -378,6 +381,9 @@ module Moped
             # common case here is a rs.stepDown() which will reinitialize the
             # connection. In this case we need to requthenticate and try again,
             # otherwise we'll just raise the error to the user.
+            if logger = Moped.logger
+              logger.info {"Received unauthorized reply querying #{collection} on #{database}: #{reply.documents[0].inspect}"}
+            end
             login(database, *auth[database])
             reply = query(database, collection, selector, options)
           else
@@ -589,6 +595,9 @@ module Moped
             replies.each_with_index do |reply, i|
               operation = operations[i]
               if reply && reply.unauthorized? && auth.has_key?(operation.database)
+                if logger = Moped.logger
+                  logger.info {"Received unauthorized reply in flush for #{operation.database}: #{reply.documents[0].inspect}"}
+                end
                 login(operation.database, *auth[operation.database])
                 flush([ops[i]])
               end

--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -267,7 +267,28 @@ module Moped
     #
     # @since 1.0.0
     def insert(database, collection, documents, options = {})
-      process(Protocol::Insert.new(database, collection, documents, options))
+      operation = Protocol::Insert.new(database, collection, documents, options)
+
+      process(operation) do |reply|
+        if reply && reply.query_failed?
+          if reply.unauthorized? && auth.has_key?(database)
+            # If we got here, most likely this is the case of Moped
+            # authenticating successfully against the node originally, but the
+            # node has been reset or gone down and come back up. The most
+            # common case here is a rs.stepDown() which will reinitialize the
+            # connection. In this case we need to requthenticate and try again,
+            # otherwise we'll just raise the error to the user.
+            if logger = Moped.logger
+              logger.debug {"  MOPED Received unauthorized reply inserting #{collection} on #{database}: #{reply.documents[0].inspect}"}
+            end
+            login(database, *auth[database])
+            reply = insert(database, collection, selector, options)
+          else
+            raise Errors::QueryFailure.new(operation, reply.documents.first)
+          end
+        end
+        reply
+      end
     end
 
     # Kill all provided cursors on the node.
@@ -590,27 +611,10 @@ module Moped
     def flush(ops = queue)
       operations, callbacks = ops.transpose
 
-      if logger = Moped.logger
-        logger.debug {"  MOPED Flushing operations #{operations.inspect}"}
-      end
-
       logging(operations) do
         ensure_connected do
           connection.write operations
           replies = connection.receive_replies(operations)
-
-          if replies && replies.length > 0
-            replies.each_with_index do |reply, i|
-              operation = operations[i]
-              if reply && reply.unauthorized? && auth.has_key?(operation.database)
-                if logger = Moped.logger
-                  logger.debug {"  MOPED Received unauthorized reply in flush for #{operation.database}: #{reply.documents[0].inspect}"}
-                end
-                login(operation.database, *auth[operation.database])
-                flush([ops[i]])
-              end
-            end
-          end
 
           replies.zip(callbacks).map do |reply, callback|
             callback ? callback[reply] : reply

--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -94,7 +94,7 @@ module Moped
         if reply.command_failure?
           if reply.unauthorized? && auth.has_key?(database)
             if logger = Moped.logger
-              logger.debug {"MOPED Received unauthorized reply for command #{cmd} on #{database}: #{reply.documents[0].inspect}"}
+              logger.debug {"  MOPED Received unauthorized reply for command #{cmd} on #{database}: #{reply.documents[0].inspect}"}
             end
             login(database, *auth[database])
             result = command(database, cmd, options)
@@ -382,7 +382,7 @@ module Moped
             # connection. In this case we need to requthenticate and try again,
             # otherwise we'll just raise the error to the user.
             if logger = Moped.logger
-              logger.debug {"MOPED Received unauthorized reply querying #{collection} on #{database}: #{reply.documents[0].inspect}"}
+              logger.debug {"  MOPED Received unauthorized reply querying #{collection} on #{database}: #{reply.documents[0].inspect}"}
             end
             login(database, *auth[database])
             reply = query(database, collection, selector, options)
@@ -502,7 +502,7 @@ module Moped
 
     def login(database, username, password)
       if logger = Moped.logger
-        logger.debug {"MOPED login for #{username} on #{database}"}
+        logger.debug {"  MOPED login for #{username} on #{database}"}
       end
 
       getnonce = Protocol::Command.new(database, getnonce: 1)
@@ -590,6 +590,10 @@ module Moped
     def flush(ops = queue)
       operations, callbacks = ops.transpose
 
+      if logger = Moped.logger
+        logger.debug {"  MOPED Flushing operations #{operations.inspect}"}
+      end
+
       logging(operations) do
         ensure_connected do
           connection.write operations
@@ -600,7 +604,7 @@ module Moped
               operation = operations[i]
               if reply && reply.unauthorized? && auth.has_key?(operation.database)
                 if logger = Moped.logger
-                  logger.debug {"MOPED Received unauthorized reply in flush for #{operation.database}: #{reply.documents[0].inspect}"}
+                  logger.debug {"  MOPED Received unauthorized reply in flush for #{operation.database}: #{reply.documents[0].inspect}"}
                 end
                 login(operation.database, *auth[operation.database])
                 flush([ops[i]])

--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -94,7 +94,7 @@ module Moped
         if reply.command_failure?
           if reply.unauthorized? && auth.has_key?(database)
             if logger = Moped.logger
-              logger.info {"Received unauthorized reply for command #{cmd} on #{database}: #{reply.documents[0].inspect}"}
+              logger.debug {"MOPED Received unauthorized reply for command #{cmd} on #{database}: #{reply.documents[0].inspect}"}
             end
             login(database, *auth[database])
             result = command(database, cmd, options)
@@ -382,7 +382,7 @@ module Moped
             # connection. In this case we need to requthenticate and try again,
             # otherwise we'll just raise the error to the user.
             if logger = Moped.logger
-              logger.info {"Received unauthorized reply querying #{collection} on #{database}: #{reply.documents[0].inspect}"}
+              logger.debug {"MOPED Received unauthorized reply querying #{collection} on #{database}: #{reply.documents[0].inspect}"}
             end
             login(database, *auth[database])
             reply = query(database, collection, selector, options)
@@ -501,6 +501,10 @@ module Moped
     end
 
     def login(database, username, password)
+      if logger = Moped.logger
+        logger.debug {"MOPED login for #{username} on #{database}"}
+      end
+
       getnonce = Protocol::Command.new(database, getnonce: 1)
       connection.write [getnonce]
       result = connection.read.documents.first
@@ -596,7 +600,7 @@ module Moped
               operation = operations[i]
               if reply && reply.unauthorized? && auth.has_key?(operation.database)
                 if logger = Moped.logger
-                  logger.info {"Received unauthorized reply in flush for #{operation.database}: #{reply.documents[0].inspect}"}
+                  logger.debug {"MOPED Received unauthorized reply in flush for #{operation.database}: #{reply.documents[0].inspect}"}
                 end
                 login(operation.database, *auth[operation.database])
                 flush([ops[i]])

--- a/spec/moped/node_spec.rb
+++ b/spec/moped/node_spec.rb
@@ -59,7 +59,8 @@ describe Moped::Node, replica_set: true do
         it "retries" do
           node
           document = { "_id" => Moped::BSON::ObjectId.new }
-          mock_reply = mock(Moped::Protocol::Reply, :unauthorized? => true)
+          mock_reply_document = mock()
+          mock_reply = mock(Moped::Protocol::Reply, :unauthorized? => true, :documents => [mock_reply_document])
           mock_connection = mock(:receive_replies => [mock_reply]).as_null_object
           call_count = 0
           real_connection = node.send(:connection)

--- a/spec/moped/node_spec.rb
+++ b/spec/moped/node_spec.rb
@@ -49,38 +49,6 @@ describe Moped::Node, replica_set: true do
     end
   end
 
-  describe "#flush" do
-    let(:session) do
-      Moped::Session.new %w[127.0.0.1:27017], database: "moped_test"
-    end
-
-    context "when inserting" do
-      context "and the database is not authorized" do
-        it "retries" do
-          node
-          document = { "_id" => Moped::BSON::ObjectId.new }
-          mock_reply_document = mock()
-          mock_reply = mock(Moped::Protocol::Reply, :unauthorized? => true, :documents => [mock_reply_document])
-          mock_connection = mock(:receive_replies => [mock_reply]).as_null_object
-          call_count = 0
-          real_connection = node.send(:connection)
-          node.stub(:connection) do
-            call_count += 1
-            if call_count == 3 || call_count == 4
-              mock_connection
-            else
-              real_connection
-            end
-          end
-          node.instance_variable_set(:@auth, {"moped_test" => {}})
-          node.should_receive(:login)
-          node.insert("moped_test", "users", [document], flags: [])
-          session[:users].find(document).one.should eq document
-        end
-      end
-    end
-  end
-
   describe "#disconnect" do
 
     context "when the node is running" do


### PR DESCRIPTION
We've been seeing something really weird in our staging database. We have a line of that that is like

```ruby
m = Model.new(...)
success = m.save()
if success
  do_work()
end
```

with safe writes turned on. We see in the Moped logs that the INSERT is happening and Mongoid thinks that everything happened successfully. However, we did some packet sniffing on the machine and saw this:

> IPX:15077  <<--  IPY:54709   129 bytes  id:a1886  661638 - 105
        reply n:1 cursorId: 0
        { err: "not authorized for insert on staging.collection_name", code: 16540, n: 0, ok: 1.0 }

It seems like the INSERT is silently failing - it is extremely hard to reproduce, perhaps we can reproduce it once an hour (however, we reproduced it a dozen times yesterday). I think this might help.

Please let me know your thoughts.