### PR TITLE
Handle Errno::ENETUNREACH socket errors

### DIFF
--- a/lib/moped/connection/socket/connectable.rb
+++ b/lib/moped/connection/socket/connectable.rb
@@ -127,6 +127,8 @@ module Moped
           raise Errors::ConnectionFailure, generate_message(e)
         rescue Errno::ETIMEDOUT => e
           raise Errors::ConnectionFailure, generate_message(e)
+        rescue Errno::ENETUNREACH => e
+          raise Errors::ConnectionFailure, generate_message(e)
         rescue IOError
           raise Errors::ConnectionFailure, "Connection timed out to Mongo on #{host}:#{port}"
         rescue OpenSSL::SSL::SSLError => e


### PR DESCRIPTION
When one of our replica set nodes went down, the exception that was being raised was a Errno::ENETUNREACH socket error. This error is not handled in moped currently, causing Mongoid not to recognize that a node was down. Therefore, handle this exception.
