### PR TITLE
Add $min and $max query modifiers.

### DIFF
--- a/lib/moped/query.rb
+++ b/lib/moped/query.rb
@@ -173,6 +173,42 @@ module Moped
       self
     end
 
+    # Specify the inclusive lower bound for a specific index in order to
+    # constrain the results of find(). min() provides a way to specify lower
+    # bounds on compound key indexes.
+    #
+    # @example Set the lower bond on the age index to 21 years
+    # (provided the collection has a {"age" => 1} index)
+    #   db[:people].find.min("age" => 21)
+    #
+    # @param [ Hash ] indexBounds The inclusive lower bound for the index keys.
+    #
+    # @return [ Query ] self
+    #
+    def min(index_bounds)
+      upgrade_to_advanced_selector
+      operation.selector["$min"] = index_bounds
+      self
+    end
+
+    # Specifies the exclusive upper bound for a specific index in order to
+    # constrain the results of find().  max() provides a way to specify an
+    # upper bound on compound key indexes.
+    #
+    # @example Set the upper bond on the age index to 21 years
+    # (provided the collection has a {"age" => -11} index)
+    #   db[:people].find.min("age" => 21)
+    #
+    # @param [ Hash ] indexBounds The exclusive upper bound for the index keys.
+    #
+    # @return [ Query ] self
+    #
+    def max(index_bounds)
+      upgrade_to_advanced_selector
+      operation.selector["$max"] = index_bounds
+      self
+    end
+
     # Initialize the query.
     #
     # @example Initialize the query.

--- a/spec/moped/query_spec.rb
+++ b/spec/moped/query_spec.rb
@@ -404,6 +404,50 @@ describe Moped::Query do
       end
     end
 
+    describe "#min" do
+      let(:document1) do
+        { "_id" => BSON::ObjectId.new, "scope" => scope, "n" => 0 }
+      end
+
+      let(:document2) do
+        { "_id" => BSON::ObjectId.new, "scope" => scope, "n" => 1 }
+      end
+
+      let(:documents) do
+        [ document1, document2 ]
+      end
+
+      before do
+        users.insert(documents)
+      end
+
+      it "filter out documents lt than the indexed value" do
+        users.find(scope: scope).min(_id: document2['_id']).to_a.should eq [ document2 ]
+      end
+    end
+
+    describe "#max" do
+      let(:document1) do
+        { "_id" => BSON::ObjectId.new, "scope" => scope, "n" => 0 }
+      end
+
+      let(:document2) do
+        { "_id" => BSON::ObjectId.new, "scope" => scope, "n" => 1 }
+      end
+
+      let(:documents) do
+        [ document1, document2 ]
+      end
+
+      before do
+        users.insert(documents)
+      end
+
+      it "filter out documents gte than the indexed value" do
+        users.find(scope: scope).max(_id: document2['_id']).to_a.should eq [ document1 ]
+      end
+    end
+
     describe "#distinct" do
 
       let(:documents) do


### PR DESCRIPTION
Hello,

For my use case I need to be able to set the $min and $max on the query (as explained here http://docs.mongodb.org/manual/reference/operator/meta/max/). The code to make this possible is included in this PR, please let me know if it looks like something that could be merged.

Thanks !
