### PR TITLE
Don't clear the auth when disconnecting, it can mess up queries on the n...

### DIFF
--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -109,7 +109,6 @@ module Moped
     #
     # @since 1.2.0
     def disconnect
-      auth.clear
       connection.disconnect
     end
 


### PR DESCRIPTION
...ode that are unauthorized due to a failover.

---

When we restart our mongos' or have a stepdown, we've seen in-flight operations fail for being unauthorized and not reconnect. After debugging in our staging environment (I could never reproduce this locally with a local replica set and mongos), it seems that `@auth` is empty when the `query_failed?` so if `reply.unauthorized? && auth.has_key?(database)` evaluates to false. I added some log statements, and the auth gets cleared due to a disconnect.

I don't think we need to clear auth credentials on a disconnect, this also avoids this issue. 
