### PR TITLE
Fixes #236 Add :resolve configuration option

### DIFF
--- a/lib/moped/address.rb
+++ b/lib/moped/address.rb
@@ -45,17 +45,23 @@ module Moped
     #
     # @since 2.0.0
     def resolve(node)
+      unless node.resolve?
+        @resolved = "#{host}:#{port}"
+        @ip       = nil
+        return @resolved
+      end
+
       begin
         Timeout::timeout(@timeout) do
           Resolv.each_address(host) do |ip|
             if ip =~ Resolv::IPv4::Regex
-              @ip ||= ip
+              @ip = ip
               break
             end
           end
           raise Resolv::ResolvError unless @ip
         end
-        @resolved ||= "#{ip}:#{port}"
+        @resolved = "#{ip}:#{port}"
       rescue Timeout::Error, Resolv::ResolvError, SocketError
         Loggable.warn("  MOPED:", "Could not resolve IP for: #{original}", "n/a")
         node.down! and false

--- a/lib/moped/connection.rb
+++ b/lib/moped/connection.rb
@@ -16,7 +16,7 @@ module Moped
     TIMEOUT = 5
 
     # @!attribute host
-    #   @return [ String ] The ip address of the host.
+    #   @return [ String ] The host name or ip address of the host.
     # @!attribute options
     #   @return [ Hash ] The connection options.
     # @!attribute port

--- a/lib/moped/connection/manager.rb
+++ b/lib/moped/connection/manager.rb
@@ -55,7 +55,8 @@ module Moped
           timeout: node.options[:pool_timeout] || TIMEOUT
         ) do
           Connection.new(
-            node.address.ip,
+            # Use the host name if the ip has not been resolved
+            node.address.ip || node.address.host,
             node.address.port,
             node.options[:timeout] || Connection::TIMEOUT,
             node.options

--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -72,6 +72,18 @@ module Moped
       @auto_discovering ||= options[:auto_discover].nil? ? true : options[:auto_discover]
     end
 
+    # Must the node resolve its host name to its IP address
+    #
+    # @example Must the node resolve its node name?
+    #   node.resolve?
+    #
+    # @return [ true, false ] If the node resolves its host name to its IP address
+    #
+    # @since 2.0.0
+    def resolve?
+      @resolve ||= options[:resolve].nil? ? true : options[:resolve]
+    end
+
     # Execute a command against a database.
     #
     # @example Execute a command.

--- a/lib/moped/session.rb
+++ b/lib/moped/session.rb
@@ -245,6 +245,11 @@ module Moped
     # @since 1.5.0
     option(:auto_discover).allow(true, false)
 
+    # Setup validation of allowed resolve options
+    #
+    # @since 2.0.0
+    option(:resolve).allow(true, false)
+
     # Initialize a new database session.
     #
     # @example Initialize a new session.

--- a/spec/moped/address_spec.rb
+++ b/spec/moped/address_spec.rb
@@ -91,6 +91,29 @@ describe Moped::Address do
       end
     end
 
+    context "when the host is a name and is not resolved" do
+
+      let(:node) do
+        Moped::Node.new("localhost:27017", resolve: false)
+      end
+
+      let(:address) do
+        Moped::Address.new("localhost:27017", 2)
+      end
+
+      before do
+        address.resolve(Moped::Node.new("localhost:27017", resolve: false))
+      end
+
+      it "sets the resolved address" do
+        expect(address.resolved).to eq("localhost:27017")
+      end
+
+      it "sets the ip" do
+        expect(address.ip).to eq(nil)
+      end
+    end
+
     context "when the host cannot be resolved" do
 
       let(:node) do


### PR DESCRIPTION
Disable using expensive Resolv.each_address when not required since it can result in significant slow down when including remote nodes in the cluster
