### PR TITLE
Lock rspec to ~> 2.14.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 group :test do
-  gem "rspec", "~> 2.13"
+  gem "rspec", "~> 2.14.1"
   if ENV["CI"]
     gem "coveralls", :require => false
   else


### PR DESCRIPTION
~> 2.13 install the 3.0 prelease versions (2.99) now, this locks rspec to the latest 2.x release.
