### PR TITLE
Lower refresh_interval default from 300 to 10 sec

### DIFF
--- a/lib/moped/cluster.rb
+++ b/lib/moped/cluster.rb
@@ -17,7 +17,7 @@ module Moped
     # The default interval that a node should be refreshed in.
     #
     # @since 2.0.0
-    REFRESH_INTERVAL = 300
+    REFRESH_INTERVAL = 10
 
     # The default time to wait to retry an operation.
     #
@@ -94,7 +94,7 @@ module Moped
     # @option options :down_interval number of seconds to wait before attempting
     #   to reconnect to a down node. (30)
     # @option options :refresh_interval number of seconds to cache information
-    #   about a node. (300)
+    #   about a node. (10)
     # @option options [ Integer ] :timeout The time in seconds to wait for an
     #   operation to timeout. (5)
     #


### PR DESCRIPTION
Current default is too high- if a failover occurs, an existing connection won't detect a new PRIMARY for potentially up to 300 seconds.

I propose changing the default to 10 or 5 seconds. See Durran's code here for reference:
https://github.com/mongodb/mongo-ruby-driver/blob/89733bc5cfab5b82228d663c285135f2deea6cd0/lib/mongo/server/monitor.rb#L28-L58
