### PR TITLE
allow multiple write options including wtimeout

### DIFF
--- a/lib/moped/session.rb
+++ b/lib/moped/session.rb
@@ -179,6 +179,8 @@ module Moped
 
       option(:w).allow(Optionable.any(Integer))
       option('w').allow(Optionable.any(Integer))
+      option(:w).allow(Optionable.any(String))
+      option('w').allow(Optionable.any(String))
       option(:j).allow(true, false)
       option('j').allow(true, false)
       option(:fsync).allow(true, false)


### PR DESCRIPTION
Current options only allow one single write option. Create a own Optionable object to check write option hash. Also include 'wtimeout' to allowed write options.
