### PR TITLE
Retry a connection in the case where there's a connection failure attempting auth.

### DIFF
--- a/lib/moped/errors.rb
+++ b/lib/moped/errors.rb
@@ -103,7 +103,7 @@ module Moped
       NOT_MASTER = [ 13435, 13436, 10009]
 
       # Error codes received around reconfiguration
-      CONNECTION_ERRORS_RECONFIGURATION = [ 15988, 10276, 11600, 9001, 13639, 10009 ]
+      CONNECTION_ERRORS_RECONFIGURATION = [ 15988, 10276, 11600, 9001, 13639, 10009, 11002 ]
 
       # Replica set reconfigurations can be either in the form of an operation
       # error with code 13435, or with an error message stating the server is


### PR DESCRIPTION
We had an issue with our mongos, and all our applications broke due to hundreds of thousands of these errors. As such, inspect to determine if we should attempt a retry when auth fails.

> # <Moped::Errors::AuthenticationFailure: The operation: #<Moped::Protocol::Commands::Authenticate
> 
> Sep 04 00:06:47 api-app-prd-iad-cld-ebc2c production.log:    @length=178
> Sep 04 00:06:47 api-app-prd-iad-cld-ebc2c production.log:    @request_id=251
> Sep 04 00:06:47 api-app-prd-iad-cld-ebc2c production.log:    @response_to=0
> Sep 04 00:06:47 api-app-prd-iad-cld-ebc2c production.log:    @op_code=2004
> Sep 04 00:06:47 api-app-prd-iad-cld-ebc2c production.log:    @flags=[]
> Sep 04 00:06:47 api-app-prd-iad-cld-ebc2c production.log:    @full_collection_name="production.$cmd"
> Sep 04 00:06:47 api-app-prd-iad-cld-ebc2c production.log:    @skip=0
> Sep 04 00:06:47 api-app-prd-iad-cld-ebc2c production.log:    @limit=-1
> Sep 04 00:06:47 api-app-prd-iad-cld-ebc2c production.log:    @selector={:authenticate=>1, :user=>"production", :nonce=>"REDACTED", :key=>"30326138132f0fdd844bfdbcb9069d9e"}
> Sep 04 00:06:47 api-app-prd-iad-cld-ebc2c production.log:    @fields=nil>
> Sep 04 00:06:47 api-app-prd-iad-cld-ebc2c production.log:  failed with error 11002: "exception: socket exception [CONNECT_ERROR] for REDACTED"
> Sep 04 00:06:47 api-app-prd-iad-cld-ebc2c production.log:  See https://github.com/mongodb/mongo/blob/master/docs/errors.md
> Sep 04 00:06:47 api-app-prd-iad-cld-ebc2c production.log:  for details about this error.>, 
> ["/var/www/platform/shared/api/bundle/ruby/2.1.0/bundler/gems/moped-6a0890ea51d4/lib/moped/node.rb:564:in `login'", "/var/www/platform/shared/api/bundle/ruby/2.1.0/bundler/gems/moped-6a0890ea51d4/lib/moped/node.rb:57:in`block in apply_auth'", "/var/www/platform/shared/api/bundle/ruby/2.1.0/bundler/gems/moped-6a0890ea51d4/lib/moped/node.rb:56:in `each'", "/var/www/platform/shared/api/bundle/ruby/2.1.0/bundler/gems/moped-6a0890ea51d4/lib/moped/node.rb:56:in`apply_auth'", "/var/www/platform/shared/api/bundle/ruby/2.1.0/bundler/gems/moped-6a0890ea51d4/lib/moped/cluster.rb:251:in `with_secondary'", 
