### PR TITLE
batch_size 1 prevents iteration over query results

### DIFF
--- a/spec/moped/cursor_spec.rb
+++ b/spec/moped/cursor_spec.rb
@@ -53,6 +53,31 @@ describe Moped::Cursor do
       end
     end
 
+    context "when the query has a batch size of 1" do
+      let(:query) do
+        users.find.batch_size(1)
+      end
+
+      let(:users) do
+        session[:users]
+      end
+
+      before do
+        users.find.remove_all
+        users.insert([ { "name" => "one" } , { "name" => "two" } , { "name" => "three" } ])
+      end
+
+      it "iterates over each user" do
+        docs = []
+
+        query.each do |doc|
+          docs << doc
+        end
+
+        docs.count.should eq(3)
+      end
+    end
+
     context "when the query has a limit and batch size" do
 
       let(:query) do


### PR DESCRIPTION
If you set batch_size to 1, you cannot use `each` to iterate over a collection. It looks like a cursor_id is never assigned, so `while more?` is false in `Cursor#each`. Is this a moped or a mongodb issue? I realise it's a bit of an odd thing to do, but I'm adding Mongoid support to a gem whose test suite is setting batch_size to 1 for a particular test case. 
