### PR TITLE
2.0.1 fix retries operations

### DIFF
--- a/lib/moped/query.rb
+++ b/lib/moped/query.rb
@@ -21,6 +21,7 @@ module Moped
   #   people.find.count # => 1
   class Query
     include Enumerable
+    include Retryable
 
     # @attribute [r] collection The collection to execute the query on.
     # @attribute [r] operation The query operation.
@@ -321,14 +322,16 @@ module Moped
     #
     # @since 1.0.0
     def remove
-      cluster.with_primary do |node|
-        node.remove(
-          operation.database,
-          operation.collection,
-          operation.basic_selector,
-          write_concern,
-          flags: [ :remove_first ]
-        )
+      with_retry(cluster) do
+        cluster.with_primary do |node|
+          node.remove(
+            operation.database,
+            operation.collection,
+            operation.basic_selector,
+            write_concern,
+            flags: [ :remove_first ]
+          )
+        end
       end
     end
 
@@ -341,13 +344,15 @@ module Moped
     #
     # @since 1.0.0
     def remove_all
-      cluster.with_primary do |node|
-        node.remove(
-          operation.database,
-          operation.collection,
-          operation.basic_selector,
-          write_concern
-        )
+      with_retry(cluster) do
+        cluster.with_primary do |node|
+          node.remove(
+            operation.database,
+            operation.collection,
+            operation.basic_selector,
+            write_concern
+          )
+        end
       end
     end
 
@@ -423,15 +428,17 @@ module Moped
     #
     # @since 1.0.0
     def update(change, flags = nil)
-      cluster.with_primary do |node|
-        node.update(
-          operation.database,
-          operation.collection,
-          operation.selector["$query"] || operation.selector,
-          change,
-          write_concern,
-          flags: flags
-        )
+      with_retry(cluster) do
+        cluster.with_primary do |node|
+          node.update(
+            operation.database,
+            operation.collection,
+            operation.selector["$query"] || operation.selector,
+            change,
+            write_concern,
+            flags: flags
+          )
+        end
       end
     end
 

--- a/lib/moped/read_preference/selectable.rb
+++ b/lib/moped/read_preference/selectable.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require "moped/retryable"
 module Moped
   module ReadPreference
 
@@ -7,6 +8,7 @@ module Moped
     #
     # @since 2.0.0
     module Selectable
+      include Retryable
 
       # @!attribute tags
       #   @return [ Array<Hash> ] The tag sets.
@@ -38,41 +40,6 @@ module Moped
         options[:flags] ||= []
         options[:flags] |= [ :slave_ok ]
         options
-      end
-
-      private
-
-      # Execute the provided block on the cluster and retry if the execution
-      # fails.
-      #
-      # @api private
-      #
-      # @example Execute with retry.
-      #   preference.with_retry(cluster) do
-      #     cluster.with_primary do |node|
-      #       node.refresh
-      #     end
-      #   end
-      #
-      # @param [ Cluster ] cluster The cluster.
-      # @param [ Integer ] retries The number of times to retry.
-      #
-      # @return [ Object ] The result of the block.
-      #
-      # @since 2.0.0
-      def with_retry(cluster, retries = cluster.max_retries, &block)
-        begin
-          block.call
-        rescue Errors::ConnectionFailure, Errors::PotentialReconfiguration => e
-          if retries > 0
-            Loggable.warn("  MOPED:", "Retrying connection attempt #{retries} more time(s).", "n/a")
-            sleep(cluster.retry_interval)
-            cluster.refresh
-            with_retry(cluster, retries - 1, &block)
-          else
-            raise e
-          end
-        end
       end
     end
   end

--- a/lib/moped/read_preference/selectable.rb
+++ b/lib/moped/read_preference/selectable.rb
@@ -63,7 +63,7 @@ module Moped
       def with_retry(cluster, retries = cluster.max_retries, &block)
         begin
           block.call
-        rescue Errors::ConnectionFailure => e
+        rescue Errors::ConnectionFailure, Errors::PotentialReconfiguration => e
           if retries > 0
             Loggable.warn("  MOPED:", "Retrying connection attempt #{retries} more time(s).", "n/a")
             sleep(cluster.retry_interval)

--- a/lib/moped/retryable.rb
+++ b/lib/moped/retryable.rb
@@ -29,7 +29,8 @@ module Moped
       begin
         block.call
       rescue Errors::ConnectionFailure, Errors::PotentialReconfiguration => e
-        raise e if e.is_a?(Errors::PotentialReconfiguration) && ! e.message.include?("not master")
+        raise e if e.is_a?(Errors::PotentialReconfiguration) &&
+          ! (e.message.include?("not master") || e.message.include?("Not primary"))
 
         if retries > 0
           Loggable.warn("  MOPED:", "Retrying connection attempt #{retries} more time(s).", "n/a")

--- a/lib/moped/retryable.rb
+++ b/lib/moped/retryable.rb
@@ -1,0 +1,45 @@
+# encoding: utf-8
+module Moped
+  # Provides the shared behaviour for retry failed operations.
+  #
+  # @since 2.0.0
+  module Retryable
+
+    private
+
+    # Execute the provided block on the cluster and retry if the execution
+    # fails.
+    #
+    # @api private
+    #
+    # @example Execute with retry.
+    #   preference.with_retry(cluster) do
+    #     cluster.with_primary do |node|
+    #       node.refresh
+    #     end
+    #   end
+    #
+    # @param [ Cluster ] cluster The cluster.
+    # @param [ Integer ] retries The number of times to retry.
+    #
+    # @return [ Object ] The result of the block.
+    #
+    # @since 2.0.0
+    def with_retry(cluster, retries = cluster.max_retries, &block)
+      begin
+        block.call
+      rescue Errors::ConnectionFailure, Errors::PotentialReconfiguration => e
+        raise e if e.is_a?(Errors::PotentialReconfiguration) && ! e.message.include?("not master")
+
+        if retries > 0
+          Loggable.warn("  MOPED:", "Retrying connection attempt #{retries} more time(s).", "n/a")
+          sleep(cluster.retry_interval)
+          cluster.refresh
+          with_retry(cluster, retries - 1, &block)
+        else
+          raise e
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,11 @@ require "rspec"
 
 $:.unshift((Pathname(__FILE__).dirname.parent + "lib").to_s)
 
+require "timeout"
+require "benchmark"
+require "fileutils"
+require "tmpdir"
+require "tempfile"
 require "moped"
 require "support/examples"
 require "support/mongohq"
@@ -36,7 +41,118 @@ RSpec.configure do |config|
     Moped::Connection::Manager.instance_variable_set(:@pools, {})
   end
 
+  config.after(:suite) do
+    stop_mongo_server(31100)
+    stop_mongo_server(31101)
+    stop_mongo_server(31102)
+  end
+
   unless Support::MongoHQ.replica_set_configured? || Support::MongoHQ.auth_node_configured?
     $stderr.puts Support::MongoHQ.message
   end
+end
+
+def start_mongo_server(port, extra_options=nil, clean_database_files=true)
+  dbpath = File.join(Dir.tmpdir, "mongod-db", port.to_s)
+  FileUtils.mkdir_p(dbpath)
+
+  Timeout::timeout(10) do
+    loop do
+      `mongod --oplogSize 40 --noprealloc --smallfiles --port #{port} --dbpath #{dbpath} --logpath #{dbpath}/log --pidfilepath #{dbpath}/pid --fork #{extra_options}`
+      sleep 1
+      break if `echo 'db.runCommand({ping:1}).ok' | mongo --quiet --port #{port} 2>/dev/null`.chomp == "1"
+    end
+  end
+end
+
+def stop_mongo_server(port, clean_database_files=true)
+  dbpath = File.join(Dir.tmpdir, "mongod-db", port.to_s)
+  pidfile = File.join(dbpath, "pid")
+  if File.exists?(pidfile)
+    Timeout::timeout(10) do
+      loop do
+        `kill #{File.read(pidfile).chomp}`
+        sleep 1
+        break if `echo 'db.runCommand({ping:1}).ok' | mongo --quiet --port #{port} 2>/dev/null`.chomp != "1"
+      end
+    end
+  end
+
+  FileUtils.rm_rf(dbpath) if clean_database_files
+end
+
+def keyfile
+  file = File.join(Dir.tmpdir, "mongod-db", "keyfile")
+  return file if File.exists?(file)
+
+  FileUtils.mkdir_p(File.dirname(file))
+  File.open(file, "w", 0600) do |f|
+    f.puts <<-EOF.gsub /^\s+/, ""
+      SyrfEmAevWPEbgRZoZx9qZcZtJAAfd269da+kzi0H/7OuowGLxM3yGGUHhD379qP
+      nw4X8TT2T6ecx6aqJgxG+biJYVOpNK3HHU9Dp5q6Jd0bWGHGGbgFHV32/z2FFiti
+      EFLimW/vfn2DcJwTW29nQWhz2wN+xfMuwA6hVxFczlQlz5hIY0+a+bQChKw8wDZk
+      rW1OjTQ//csqPbVA8fwB49ghLGp+o84VujhRxLJ+0sbs8dKoIgmVlX2kLeHGQSf0
+      KmF9b8kAWRLwLneOR3ESovXpEoK0qpQb2ym6BNqP32JKyPA6Svb/smVONhjUI71f
+      /zQ2ETX7ylpxIzw2SMv/zOWcVHBqIbdP9Llrxb3X0EsB6J8PeI8qLjpS94FyEddw
+      ACMcAxbP+6BaLjXyJ2WsrEeqThAyUC3uF5YN/oQ9XiATqP7pDOTrmfn8LvryyzcB
+      ByrLRTPOicBaG7y13ATcCbBdrYH3BE4EeLkTUZOg7VzvRnATvDpt0wOkSnbqXow8
+      GQ6iMUgd2XvUCuknQLD6gWyoUyHiPADKrLsgnd3Qo9BPxYJ9VWSKB4phK3N7Bic+
+      BwxlcpDFzGI285GR4IjcJbRRjjywHq5XHOxrJfN+QrZ/6wy6yu2+4NTPj+BPC5iX
+      /dNllTEyn7V+pr6FiRv8rv8RcxJgf3nfn/Xz0t2zW2olcalEFxwKKmR20pZxPnSv
+      Kr6sVHEzh0mtA21LoK5G8bztXsgFgWU7hh9z8UUo7KQQnDfyPb6k4xroeeQtWBNo
+      TZF1pI5joLytNSEtT+BYA5wQSYm4WCbhG+j7ipcPIJw6Un4ZtAZs0aixDfVE0zo0
+      w2FWrYH2dmmCMbz7cEXeqvQiHh9IU/hkTrKGY95STszGGFFjhtS2TbHAn2rRoFI0
+      VwNxMJCC+9ZijTWBeGyQOuEupuI4C9IzA5Gz72048tpZ0qMJ9mOiH3lZFtNTg/5P
+      28Td2xzaujtXjRnP3aZ9z2lKytlr
+    EOF
+  end
+  file
+end
+
+def setup_replicaset_environment(with_authentication=false, replica_set_name='dev')
+  status = servers_status(with_authentication).select{|st| st == "PRIMARY" || st == "SECONDARY"}
+  has_admin = has_user_admin?(with_authentication)
+  unless status.count == 3 && status.all?{|st| st == "PRIMARY" || st == "SECONDARY"} && (with_authentication ? has_admin : !has_admin)
+    stop_mongo_server(31101)
+    stop_mongo_server(31100)
+    stop_mongo_server(31102)
+
+    options = with_authentication ? "--replSet #{replica_set_name} --keyFile #{keyfile} --auth"  : "--replSet #{replica_set_name}"
+    start_mongo_server(31100, options)
+    start_mongo_server(31101, options)
+    start_mongo_server(31102, options)
+
+    Timeout::timeout(90) do
+      sleep 5 while `echo "rs.initiate({_id : '#{replica_set_name}', 'members' : [{_id:0, host:'127.0.0.1:31100'},{_id:1, host:'127.0.0.1:31101'},{_id:2, host:'127.0.0.1:31102'}]}).ok"  | mongo --quiet --port 31100 2>/dev/null`.chomp != "1"
+      sleep 1 while !servers_status(false).all?{|st| st == "PRIMARY" || st == "SECONDARY"}
+    end
+
+    master = `echo 'db.isMaster().primary' | mongo --quiet --port 31100 2>/dev/null`.chomp
+
+    auth_credentials = ""
+    if with_authentication
+      `echo "
+      use admin;
+      db.addUser('admin', 'admin_pwd');
+      " | mongo #{master} 2>/dev/null`
+
+      auth_credentials = "-u admin -p admin_pwd --authenticationDatabase admin"
+    end
+
+    `echo "
+    use test_db;
+    db.addUser('common', 'common_pwd');
+    db.foo.ensureIndex({name:1}, {unique:1});
+    " | mongo #{master} #{auth_credentials} 2>/dev/null`
+  end
+end
+
+def servers_status(with_authentication)
+  auth = has_user_admin?(with_authentication) ? "-u admin -p admin_pwd --authenticationDatabase admin" : ""
+  `echo 'rs.status().members[0].stateStr + "|" + rs.status().members[1].stateStr + "|" + rs.status().members[2].stateStr' | mongo --quiet --port 31100 #{auth} 2>/dev/null`.chomp.split("|")
+end
+
+def has_user_admin?(with_authentication)
+  auth = with_authentication ? "-u admin -p admin_pwd --authenticationDatabase admin" : ""
+  `echo 'db.getSisterDB("admin").getUser("admin").user' | mongo --quiet --port 31100 #{auth} 2>/dev/null`.chomp   == "admin"
 end


### PR DESCRIPTION
The pull request #324 does not deal with write operations after a replicaset reconfiguration.
And the tests with replicaset simulator does not represent the real world where the election of a new primary can take some seconds.

I moved some of the code I did on pull request #315 to this one based on tag 2.0.1.
I hope you can check and merge it on master.
The tests are done with a real replicaset using the stepDown command.

Regards,
Wandenberg