### PR TITLE
Add license to gemspec

### DIFF
--- a/moped.gemspec
+++ b/moped.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://mongoid.org/en/moped"
   s.summary     = "A MongoDB driver for Ruby."
   s.description = s.summary
+  s.license     = "MIT"
   s.files = Dir.glob("lib/**/*") + %w(CHANGELOG.md LICENSE README.md)
   s.require_path = "lib"
   s.add_dependency("bson", ["~> 2.2"])


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.