### PR TITLE
Query#explain no longer discards selected operation fields

### DIFF
--- a/lib/moped/query.rb
+++ b/lib/moped/query.rb
@@ -112,7 +112,9 @@ module Moped
       explanation["$orderby"] = sort if sort
       explanation["$hint"] = hint if hint
       explanation["$maxScan"] = max_scan if max_scan
-      Query.new(collection, explanation).limit(-(operation.limit.abs)).each { |doc| return doc }
+      query = Query.new(collection, explanation)
+      query.select(operation.fields.dup) if operation.fields
+      query.limit(-(operation.limit.abs)).each { |doc| return doc }
     end
 
     # Get the first matching document.

--- a/spec/moped/query_spec.rb
+++ b/spec/moped/query_spec.rb
@@ -694,6 +694,34 @@ describe Moped::Query do
           )
         end
       end
+
+      context "when fields are specified" do
+
+        before do
+          4.times do |n|
+            users.insert({ likes: n })
+          end
+        end
+
+        let(:explain) do
+          users.find.select(likes: 1, _id: 0).explain
+        end
+
+        let(:stats) do
+          Support::Stats.collect { explain }
+        end
+
+        let(:operation) do
+          stats[node_for_reads].grep(Moped::Protocol::Query).last
+        end
+
+        it "updates to a mongo advanced selector" do
+          operation.fields.should eq(
+            likes: 1,
+            _id:   0
+          )
+        end
+      end
     end
 
     describe "#each" do


### PR DESCRIPTION
While trying to debug some indexes using explain, I noticed that the projected fields in explain do not get passed to the explained query from the original operation.  This makes the `indexOnly` attribute in the explained data appear inaccurate.