### PR TITLE
Fix #345

### DIFF
--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -150,10 +150,10 @@ module Moped
     #
     # @since 2.0.0
     def down!
-      @pool = Connection::Manager.shutdown(self)
       @down_at = Time.new
+      @pool = nil
       @latency = nil
-      true
+      Connection::Manager.shutdown(self)
     end
 
     # Yields the block if a connection can be established, retrying when a


### PR DESCRIPTION
Fixes #345.

Looks like the MRI 1.9.3 and 2.0 Travis builds timed out. I'm not familiar with the test suite; anyone know what may be going on?