### PR TITLE
Use bson 3

### DIFF
--- a/moped.gemspec
+++ b/moped.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.description = s.summary
   s.files = Dir.glob("lib/**/*") + %w(CHANGELOG.md LICENSE README.md)
   s.require_path = "lib"
-  s.add_dependency("bson", ["~> 2.2"])
+  s.add_dependency("bson", ["~> 3.0"])
   s.add_dependency("connection_pool", ["~> 2.0"])
   s.add_dependency("optionable", ["~> 0.2.0"])
 end


### PR DESCRIPTION
* Required to support newer versions of the mongo gem
* No tests break after updating the gemspec