### PR TITLE
Added oplog_replay to Protocol::Query flags.

### DIFF
--- a/lib/moped/protocol/query.rb
+++ b/lib/moped/protocol/query.rb
@@ -29,6 +29,7 @@ module Moped
       # @return [ Array ] the flags for this message
       flags :flags, tailable:          2 ** 1,
                     slave_ok:          2 ** 2,
+                    oplog_replay:      2 ** 3,
                     no_cursor_timeout: 2 ** 4,
                     await_data:        2 ** 5,
                     exhaust:           2 ** 6


### PR DESCRIPTION
Allow for selective tailing of the oplog, as documented [in the Wire Protocol](http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query) (sort of), and to maintain feature parity with [the official Ruby driver](https://github.com/mongodb/mongo-ruby-driver/blob/5b64dacc8e6b72a16b67035a484255374a3dc3cd/lib/mongo/protocol/query.rb#L119). 