### PR TITLE
Lets query errors actually get caught.

### DIFF
--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -585,14 +585,14 @@ module Moped
     def flush(ops = queue)
       operations, callbacks = ops.transpose
       logging(operations) do
-        replies = nil
         ensure_connected do |conn|
           conn.write(operations)
           replies = conn.receive_replies(operations)
+
+          replies.zip(callbacks).map do |reply, callback|
+            callback ? callback[reply] : reply
+          end.last
         end
-        replies.zip(callbacks).map do |reply, callback|
-          callback ? callback[reply] : reply
-        end.last
       end
     ensure
       ops.clear


### PR DESCRIPTION
During stepdown testing, we receive a 15988 "exception: error querying server" from node.rb:594 when reading the replies. Because this was outside the ensure_connected block, which is the only place in which Failover.get().execute() gets called, it was not handling the failover.