### PR TITLE
TCP Keepalive Support

### DIFF
--- a/lib/moped/connection.rb
+++ b/lib/moped/connection.rb
@@ -55,7 +55,7 @@ module Moped
       else
         Socket::TCP.connect(host, port, timeout)
       end
-      set_tcp_keepalive(options[:keepalive], @sock) if !!options[:keepalive]
+      set_tcp_keepalive(options[:keepalive]) if !!options[:keepalive]
     end
 
     # Is the connection connected?
@@ -256,7 +256,7 @@ module Moped
         }
       end
     else
-      def set_tcp_keepalive(keepalive, sock)
+      def set_tcp_keepalive(keepalive)
         Loggable.debug("  MOPED:", "Did not configure TCP keepalive for connection as it is not supported on this platform.", "n/a") 
       end
 

--- a/lib/moped/connection.rb
+++ b/lib/moped/connection.rb
@@ -55,7 +55,7 @@ module Moped
       else
         Socket::TCP.connect(host, port, timeout)
       end
-      set_tcp_keepalive
+      enable_tcp_keepalive
     end
 
     # Is the connection connected?
@@ -248,7 +248,7 @@ module Moped
     end
 
     if [:SOL_SOCKET, :SO_KEEPALIVE, :SOL_TCP, :TCP_KEEPIDLE, :TCP_KEEPINTVL, :TCP_KEEPCNT].all?{|c| ::Socket.const_defined? c}
-      # Enable the tcp_keepalive
+      # Enable the tcp_keepalive if configured
       #
       # @api private
       #

--- a/lib/moped/connection.rb
+++ b/lib/moped/connection.rb
@@ -55,7 +55,7 @@ module Moped
       else
         Socket::TCP.connect(host, port, timeout)
       end
-      set_tcp_keepalive(options[:keepalive]) if !!options[:keepalive]
+      set_tcp_keepalive
     end
 
     # Is the connection connected?
@@ -104,6 +104,7 @@ module Moped
       @options = options
       @sock = nil
       @request_id = 0
+      configure_tcp_keepalive(@options[:keepalive])
     end
 
     # Read from the connection.
@@ -180,6 +181,45 @@ module Moped
 
     private
 
+
+    # Configure the TCP Keeplive if it is a FixNum. If it is hash 
+    # validate he settings are FixNums.
+    #
+    # @example With a FixNum
+    #   configure_tcp_keepalive(60)
+    #
+    # @example With a Hash
+    #   configure_tcp_keepalive({:time => 30, :intvl => 20, :probes => 2})    
+    #
+    # @param [ FixNum ] | [ Hash ] Supply a Fixnum to allow the specific settings to be 
+    #                   configured for you. Supply a Hash with the :time, :intvl, and :probes
+    #                   keys to set specific values
+    #
+    # @return [ nil ] nil.
+    #
+    # @since 1.0.0
+    def configure_tcp_keepalive(keepalive)
+      case keepalive
+      when Hash
+        [:time, :intvl, :probes].each do |key|
+          unless  keepalive[key].is_a?(Fixnum)
+            raise "Expected the #{key.inspect} key in :tcp_keepalive to be a Fixnum"
+          end
+        end
+      when Fixnum
+        if keepalive >= 60
+          keepalive = {:time => keepalive - 20, :intvl => 10, :probes => 2}
+
+        elsif keepalive >= 30
+          keepalive = {:time => keepalive - 10, :intvl => 5, :probes => 2}
+
+        elsif keepalive >= 5
+          keepalive = {:time => keepalive - 2, :intvl => 2, :probes => 1}
+        end
+      end  
+      @keepalive = keepalive    
+    end
+
     # Read data from the socket until we get back the number of bytes that we
     # are expecting.
     #
@@ -207,62 +247,39 @@ module Moped
       data
     end
 
-    # Set the tcp_keepalive
-    #
-    # @api private
-    #
-    # @example With a FixNum.
-    #   set_tcp_keepalive(60)
-    #
-    # @example With a Hash
-    #   set_tcp_keepalive({time: 60, intvl: 20, probes: 2})
-    #
-    # @return [ nil ] nil.
-    #
-    # @since 2.0.5
     if [:SOL_SOCKET, :SO_KEEPALIVE, :SOL_TCP, :TCP_KEEPIDLE, :TCP_KEEPINTVL, :TCP_KEEPCNT].all?{|c| ::Socket.const_defined? c}
-      def set_tcp_keepalive(keepalive)
-        case keepalive
-        when Hash
-          [:time, :intvl, :probes].each do |key|
-            unless  keepalive[key].is_a?(Fixnum)
-              raise "Expected the #{key.inspect} key in :tcp_keepalive to be a Fixnum"
-            end
-          end
-        when Fixnum
-          if keepalive >= 60
-            keepalive = {:time => keepalive - 20, :intvl => 10, :probes => 2}
-
-          elsif keepalive >= 30
-            keepalive = {:time => keepalive - 10, :intvl => 5, :probes => 2}
-
-          elsif keepalive >= 5
-            keepalive = {:time => keepalive - 2, :intvl => 2, :probes => 1}
-          end
-        end
-
+      # Enable the tcp_keepalive
+      #
+      # @api private
+      #
+      # @example
+      #   enable_tcp_keepalive
+      #
+      # @return [ nil ] nil.
+      #
+      # @since 2.0.5
+      def enable_tcp_keepalive
+        return unless @keepalive.is_a?(Hash)
         @sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_KEEPALIVE,  true)
-        @sock.setsockopt(::Socket::SOL_TCP,    ::Socket::TCP_KEEPIDLE,  keepalive[:time])
-        @sock.setsockopt(::Socket::SOL_TCP,    ::Socket::TCP_KEEPINTVL, keepalive[:intvl])
-        @sock.setsockopt(::Socket::SOL_TCP,    ::Socket::TCP_KEEPCNT,   keepalive[:probes])
-        Loggable.debug("  MOPED:", "Configured TCP keepalive for connection with #{keepalive.inspect}", "n/a") 
-      end
-
-      def get_tcp_keepalive
-        {
-          :time   => @sock.getsockopt(::Socket::SOL_TCP, ::Socket::TCP_KEEPIDLE).int,
-          :intvl  => @sock.getsockopt(::Socket::SOL_TCP, ::Socket::TCP_KEEPINTVL).int,
-          :probes => @sock.getsockopt(::Socket::SOL_TCP, ::Socket::TCP_KEEPCNT).int,
-        }
+        @sock.setsockopt(::Socket::SOL_TCP,    ::Socket::TCP_KEEPIDLE,  @keepalive[:time])
+        @sock.setsockopt(::Socket::SOL_TCP,    ::Socket::TCP_KEEPINTVL, @keepalive[:intvl])
+        @sock.setsockopt(::Socket::SOL_TCP,    ::Socket::TCP_KEEPCNT,   @keepalive[:probes])
+        Loggable.debug("  MOPED:", "Configured TCP keepalive for connection with #{@keepalive.inspect}", "n/a") 
       end
     else
-      def set_tcp_keepalive(keepalive)
+      # Skeleton method that doesn't enable the tcp_keepalive.
+      # It simply logs a message saying the feature isn't supported.
+      #
+      # @api private
+      #
+      # @example With a Hash
+      #   enable_tcp_keepalive
+      #
+      # @return [ nil ] nil.
+      #
+      # @since 2.0.5      
+      def enable_tcp_keepalive
         Loggable.debug("  MOPED:", "Did not configure TCP keepalive for connection as it is not supported on this platform.", "n/a") 
-      end
-
-      def get_tcp_keepalive
-        {
-        }
       end
     end    
 

--- a/lib/moped/connection.rb
+++ b/lib/moped/connection.rb
@@ -195,7 +195,7 @@ module Moped
     #                   configured for you. Supply a Hash with the :time, :intvl, and :probes
     #                   keys to set specific values
     #
-    # @return [ nil ] nil.
+    # @return The configured keepalive Hash or nil. 
     #
     # @since 1.0.0
     def configure_tcp_keepalive(keepalive)

--- a/lib/moped/connection.rb
+++ b/lib/moped/connection.rb
@@ -245,7 +245,7 @@ module Moped
         @sock.setsockopt(::Socket::SOL_TCP,    ::Socket::TCP_KEEPIDLE,  keepalive[:time])
         @sock.setsockopt(::Socket::SOL_TCP,    ::Socket::TCP_KEEPINTVL, keepalive[:intvl])
         @sock.setsockopt(::Socket::SOL_TCP,    ::Socket::TCP_KEEPCNT,   keepalive[:probes])
-        puts "Configured TCP Keepalive for Moped Connection to #{keepalive.inspect}"
+        Loggable.debug("  MOPED:", "Configured TCP keepalive for connection with #{keepalive.inspect}", "n/a") 
       end
 
       def get_tcp_keepalive
@@ -257,7 +257,7 @@ module Moped
       end
     else
       def set_tcp_keepalive(keepalive, sock)
-        puts "Did not configure TCP Keepalive for Moped Connection. Keepalive: #{keepalive}"
+        Loggable.debug("  MOPED:", "Did not configure TCP keepalive for connection as it is not supported on this platform.", "n/a") 
       end
 
       def get_tcp_keepalive

--- a/lib/moped/connection.rb
+++ b/lib/moped/connection.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "moped/connection/manager"
 require "moped/connection/sockets"
+require "socket"
 
 module Moped
 
@@ -39,7 +40,7 @@ module Moped
 
 
 
-    if [:SOL_SOCKET, :SO_KEEPALIVE, :SOL_TCP, :TCP_KEEPIDLE, :TCP_KEEPINTVL, :TCP_KEEPCNT].all?{|c| Socket.const_defined? c}
+    if [:SOL_SOCKET, :SO_KEEPALIVE, :SOL_TCP, :TCP_KEEPIDLE, :TCP_KEEPINTVL, :TCP_KEEPCNT].all?{|c| ::Socket.const_defined? c}
       def set_tcp_keepalive(keepalive,sock)
         case keepalive
         when Hash
@@ -60,22 +61,23 @@ module Moped
           end
         end
 
-        sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE,  true)
-        sock.setsockopt(Socket::SOL_TCP,    Socket::TCP_KEEPIDLE,  keepalive[:time])
-        sock.setsockopt(Socket::SOL_TCP,    Socket::TCP_KEEPINTVL, keepalive[:intvl])
-        sock.setsockopt(Socket::SOL_TCP,    Socket::TCP_KEEPCNT,   keepalive[:probes])
-        Rails.logger.debug "Configured TCP Keepalive for Moped Connection to #{keepalive.inspect}"
+        sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_KEEPALIVE,  true)
+        sock.setsockopt(::Socket::SOL_TCP,    ::Socket::TCP_KEEPIDLE,  keepalive[:time])
+        sock.setsockopt(::Socket::SOL_TCP,    ::Socket::TCP_KEEPINTVL, keepalive[:intvl])
+        sock.setsockopt(::Socket::SOL_TCP,    ::Socket::TCP_KEEPCNT,   keepalive[:probes])
+        puts "Configured TCP Keepalive for Moped Connection to #{keepalive.inspect}"
       end
 
       def get_tcp_keepalive
         {
-          :time   => @sock.getsockopt(Socket::SOL_TCP, Socket::TCP_KEEPIDLE).int,
-          :intvl  => @sock.getsockopt(Socket::SOL_TCP, Socket::TCP_KEEPINTVL).int,
-          :probes => @sock.getsockopt(Socket::SOL_TCP, Socket::TCP_KEEPCNT).int,
+          :time   => @sock.getsockopt(::Socket::SOL_TCP, ::Socket::TCP_KEEPIDLE).int,
+          :intvl  => @sock.getsockopt(::Socket::SOL_TCP, ::Socket::TCP_KEEPINTVL).int,
+          :probes => @sock.getsockopt(::Socket::SOL_TCP, ::Socket::TCP_KEEPCNT).int,
         }
       end
     else
       def set_tcp_keepalive(keepalive, sock)
+        Rails.logger.debug "Did not configure TCP Keepalive for Moped Connection."
       end
 
       def get_tcp_keepalive
@@ -99,7 +101,7 @@ module Moped
       else
         Socket::TCP.connect(host, port, timeout)
       end
-      set_tcp_keepalive(60, @sock)
+      set_tcp_keepalive(5, @sock)
     end
 
     # Is the connection connected?

--- a/lib/moped/connection.rb
+++ b/lib/moped/connection.rb
@@ -279,6 +279,7 @@ module Moped
       #
       # @since 2.0.5      
       def enable_tcp_keepalive
+        return unless @keepalive.is_a?(Hash)
         Loggable.debug("  MOPED:", "Did not configure TCP keepalive for connection as it is not supported on this platform.", "n/a") 
       end
     end    

--- a/lib/moped/session.rb
+++ b/lib/moped/session.rb
@@ -240,6 +240,11 @@ module Moped
     # @since 2.0.0
     option(:timeout).allow(Optionable.any(Numeric))
 
+    # Setup validation of allowed timeout options. (Any numeric)
+    #
+    # @since 2.0.5
+    option(:keepalive).allow(Optionable.any(Fixnum), Optionable.any(Hash))   
+
     # Pass an object that responds to instrument as an instrumenter.
     #
     # @since 2.0.0


### PR DESCRIPTION
I've ported TCP Keepalive support from the redis-rb client. Quite often firewalls exist between the mongo client and the server. These firewalls aren't always configured to perform a proper fin/ack sequence when closing idle connections. This causes moped and other TCP based client to simply hang on the next request until the underlying operating system determines the connection has been closed.

Linux has support for TCP keepalives on sockets. My implementation ensures that the appropriate methods are only created if supported by the platform. If not supported, an alternate method is created with a simple log statement to let the user know Keepalives won't be available on that platform. Conditional method creation ensures performance by not having to check for the constants on every connection calls.

I'd like to give this code back to mongoid/moped to help make the socket connections more resilient.
