### PR TITLE
Use \A \z for checking regex on ObjectId.legal?

### DIFF
--- a/lib/moped/bson/object_id.rb
+++ b/lib/moped/bson/object_id.rb
@@ -244,7 +244,7 @@ module Moped
         #
         # @since 1.0.0
         def legal?(string)
-          /\A\h{24}\Z/ === string.to_s
+          string.to_s =~ /\A\h{24}\z/ ? true : false
         end
 
         # Create a new object id from some raw data.

--- a/spec/moped/bson/object_id_spec.rb
+++ b/spec/moped/bson/object_id_spec.rb
@@ -175,6 +175,12 @@ describe Moped::BSON::ObjectId do
       end
     end
 
+    context "when the string ends with newline character" do
+      it "returns false" do
+        described_class.legal?("#{'a' * 24}\n").should be_false
+      end
+    end
+
     context "when the string is a valid object id" do
       it "returns true" do
         described_class.legal?("a" * 24).should be_true


### PR DESCRIPTION
Patching DoS vulnerability due to incorrect checking of newlines.

See: http://sakurity.com/blog/2015/06/04/mongo_ruby_regexp.html