### PR TITLE
Improves Moped failover.

### DIFF
--- a/lib/moped/connection/manager.rb
+++ b/lib/moped/connection/manager.rb
@@ -48,10 +48,17 @@ module Moped
       #
       # @since 2.0.3
       def shutdown(node)
+        pool = nil
         MUTEX.synchronize do
           pool = pools.delete(node.address.resolved)
-          pool.shutdown{ |conn| conn.disconnect } if pool
-          nil
+        end
+        pool.shutdown{ |conn| conn.disconnect } if pool
+        nil
+      end
+
+      def delete_pool(node)
+        MUTEX.synchronize do
+          pools.delete(node.address.resolved)
         end
       end
 

--- a/lib/moped/errors.rb
+++ b/lib/moped/errors.rb
@@ -112,10 +112,10 @@ module Moped
     class PotentialReconfiguration < MongoError
 
       # Not master error codes.
-      NOT_MASTER = [ 13435, 13436, 10009, 15986 ]
+      NOT_MASTER = [ 13435, 13436, 10009, 15986, 83 ]
 
       # Error codes received around reconfiguration
-      CONNECTION_ERRORS_RECONFIGURATION = [ 15988, 10276, 11600, 9001, 13639, 10009, 11002 ]
+      CONNECTION_ERRORS_RECONFIGURATION = [ 15988, 10276, 11600, 9001, 13639, 10009, 11002, 7 ]
 
       # Replica set reconfigurations can be either in the form of an operation
       # error with code 13435, or with an error message stating the server is
@@ -126,7 +126,8 @@ module Moped
       end
 
       def connection_failure?
-        CONNECTION_ERRORS_RECONFIGURATION.include?(details["code"])
+        err = details["err"] || details["errmsg"] || details["$err"] || ""
+        CONNECTION_ERRORS_RECONFIGURATION.include?(details["code"]) || err.include?("could not get last error") || err.include?("connection attempt failed")
       end
 
       # Is the error due to a namespace not being found?

--- a/lib/moped/failover.rb
+++ b/lib/moped/failover.rb
@@ -21,7 +21,8 @@ module Moped
       Errors::ConnectionFailure => Retry,
       Errors::CursorNotFound => Ignore,
       Errors::OperationFailure => Reconfigure,
-      Errors::QueryFailure => Reconfigure
+      Errors::QueryFailure => Reconfigure,
+      Errors::PoolTimeout => Retry
     }.freeze
 
     # Get the appropriate failover handler given the provided exception.

--- a/lib/moped/loggable.rb
+++ b/lib/moped/loggable.rb
@@ -42,6 +42,10 @@ module Moped
       Moped.logger.debug([ prefix, payload, "runtime: #{runtime}" ].join(' '))
     end
 
+    def self.info(prefix, payload, runtime)
+      Moped.logger.info([ prefix, payload, "runtime: #{runtime}" ].join(' '))
+    end
+
     # Log the payload to warn.
     #
     # @example Log to warn.

--- a/lib/moped/retryable.rb
+++ b/lib/moped/retryable.rb
@@ -33,7 +33,7 @@ module Moped
           ! (e.message.include?("not master") || e.message.include?("Not primary"))
 
         if retries > 0
-          Loggable.warn("  MOPED:", "Retrying connection attempt #{retries} more time(s).", "n/a")
+          Loggable.warn("  MOPED:", "Retrying connection attempt #{retries} more time(s), nodes is #{cluster.nodes.inspect}, seeds are #{cluster.seeds.inspect}, cluster is #{cluster.inspect}. Error backtrace is #{e.backtrace}.", "n/a")
           sleep(cluster.retry_interval)
           cluster.refresh
           with_retry(cluster, retries - 1, &block)


### PR DESCRIPTION
Changes:

* Significantly bumps up the timeout in `Address#resolve`. IMO this timeout should be removed entirely, as it does not play well with multithreaded code. Also adds retry logic to DNS resolution.
* Separates out the shutdown of a pool from the mutex which handles removing it from `pools`, as a shutdown can take a long time or just fail altogether.
* Add `Retryable` and adds more `with_retry` handling. Taken from @wandenberg's pulls; I then added it to `Cursor#get_more`.
* Add more connection failure error codes, as well as some unfortunate magic string detection for connection failure. I don't know if Mongo 3.0 has improved that situation, but at least in 2.4 and 2.6 you still need to inspect the error message since it doesn't always return with an error code.
* Fixes `Node#flush` to actually catch query errors (see https://github.com/mongoid/moped/pull/369)
* Fixes #361; retries auth and retries a query if the reply is `unauthorized?` (that code completely regressed from 1.5.x; `unauthorized?` wasn't called anywhere)