### PR TITLE
Mark node as not down when alive connection was acquired

### DIFF
--- a/lib/moped/node.rb
+++ b/lib/moped/node.rb
@@ -187,7 +187,11 @@ module Moped
 
       begin
         connection do |conn|
-          connect(conn) unless conn.alive?
+          if conn.alive?
+            @down_at = nil
+          else
+            connect(conn)
+          end
           conn.apply_credentials(@credentials)
           stack(:connection) << conn
           yield(conn)

--- a/spec/moped/node_spec.rb
+++ b/spec/moped/node_spec.rb
@@ -309,6 +309,21 @@ describe Moped::Node, replica_set: true do
         end
       end
     end
+
+    context 'when node was down' do
+      before { node.down! }
+
+      context 'and good connection popped out of the pool' do
+        before { allow_any_instance_of(Moped::Connection).to receive(:alive?).and_return true }
+
+        it 'marks node as not down' do
+          node.ensure_connected do
+            node.command("admin", ping: 1)
+          end
+          expect(node).not_to be_down
+        end
+      end
+    end
   end
 
   describe "#initialize" do


### PR DESCRIPTION
I've discovered this problem when running latest moped:master with thin server
in threaded mode (`--threaded`). We have one Mongo server and when it
goes down for a few secs, some of our app servers are unable to reconnect to
it. We see lots of log output like this:

   MOPED: Retrying connection attempt 1 more time(s), nodes is [], seeds are
   MOPED: Retrying connection attempt 1 more time(s), nodes is [], seeds are
   MOPED: Retrying connection attempt 1 more time(s), nodes is [], seeds are